### PR TITLE
Update dependency libraries and make main.cpp build with clang

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "23.0.3"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 24
     }
     sourceSets {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'com.nononsenseapps:filepicker:2.5.2'
-    compile 'com.android.support:support-v4:24.1.1'
-    compile 'com.android.support:appcompat-v7:24.1.1'
+    compile 'com.android.support:support-v4:24.2.1'
+    compile 'com.android.support:appcompat-v7:24.2.1'
 }
 buildscript {
     ext.kotlin_version = '1.0.3'

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -196,6 +196,9 @@ void sendPropertyUpdateToJava(JNIEnv *env, mpv_event_property *prop) {
         jvalue = env->NewStringUTF(*(const char**)prop->data);
         env->CallStaticVoidMethod(clazz, mid, jprop, jvalue);
         break;
+    default:
+        ALOGV("sendPropertyUpdateToJava: Unknown property update format received in callback: %d!", prop->format);
+        break;
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 10 13:11:49 EEST 2016
+#Thu Aug 25 01:00:47 EEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Now builds with clang if you specify `NDK_TOOLCHAIN_VERSION=clang`
Also bumps the mindSdkVersion to 21.