### PR TITLE
[WIP] Use mpv_opengl_cb_set_update_callback() to optimize rendering

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVLib.java
+++ b/app/src/main/java/is/xyz/mpv/MPVLib.java
@@ -5,6 +5,7 @@ package is.xyz.mpv;
 import java.util.ArrayList;
 import java.util.List;
 import android.content.Context;
+import android.opengl.GLSurfaceView;
 
 public class MPVLib {
 
@@ -18,7 +19,7 @@ public class MPVLib {
      public static native void create(Context appctx);
      public static native void init();
      public static native void destroy();
-     public static native void initGL();
+     public static native void initGL(GLSurfaceView view);
      public static native void destroyGL();
 
      public static native void resize(int width, int height);

--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -98,9 +98,10 @@ internal class MPVView(context: Context, attrs: AttributeSet) : GLSurfaceView(co
         // supporting OpenGL ES 3.0 or later backwards-compatible versions.
         setEGLConfigChooser(8, 8, 8, 0, 16, 0)
         setEGLContextClientVersion(2)
-        val renderer = Renderer()
+        val renderer = Renderer(this)
         renderer.setFilePath(filePath)
         setRenderer(renderer)
+        renderMode = RENDERMODE_WHEN_DIRTY
     }
 
     override fun onPause() {
@@ -239,7 +240,7 @@ internal class MPVView(context: Context, attrs: AttributeSet) : GLSurfaceView(co
     fun cycleSub() = MPVLib.command(arrayOf("cycle", "sub"))
     fun cycleHwdec() = MPVLib.setPropertyString("hwdec", if (hwdecActive!!) "no" else "mediacodec")
 
-    private class Renderer : GLSurfaceView.Renderer {
+    private class Renderer(val glView: MPVView) : GLSurfaceView.Renderer {
         private var filePath: String? = null
 
         override fun onDrawFrame(gl: GL10) {
@@ -253,7 +254,7 @@ internal class MPVView(context: Context, attrs: AttributeSet) : GLSurfaceView(co
 
         override fun onSurfaceCreated(gl: GL10, config: EGLConfig) {
             Log.w(TAG, "Creating libmpv GL surface")
-            MPVLib.initGL()
+            MPVLib.initGL(glView)
             if (filePath != null) {
                 MPVLib.command(arrayOf("loadfile", filePath as String))
                 filePath = null

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -100,7 +100,7 @@ static bool acquire_java_stuff(JavaVM *vm, JNIEnv **env)
 static void render_cb(void *data)
 {
     JNIEnv *env;
-    if (glView == null)
+    if (glView == NULL)
         return;
     if (!acquire_java_stuff(g_vm, &env))
         return;

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -102,7 +102,9 @@ static void *render_cb(void *data)
     JNIEnv *env;
     if (!acquire_java_stuff(g_vm, &env))
         return;
-    return env->CallVoidMethod(glView, java_GLSurfaceView_requestRender);
+    env->CallVoidMethod(glView, java_GLSurfaceView_requestRender);
+    g_vm->DetachCurrentThread();
+    return;
 }
 
 static void prepare_environment(JNIEnv *env, jobject appctx) {

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -80,9 +80,9 @@ static void init_methods_cache(JNIEnv *env) {
     java_Boolean = FIND_CLASS("java/lang/Boolean");
     java_Boolean_init = env->GetMethodID(java_Boolean, "<init>", "(Z)V");
     java_Boolean_booleanValue = env->GetMethodID(java_Boolean, "booleanValue", "()Z");
-    jclass java_GLSurfaceView = FIND_CLASS("android/opengl/GLSurfaceView");
-    java_GLSurfaceView_requestRender = env->GetMethodID(java_GLSurfaceView, "requestRender", "()V");
     #undef FIND_CLASS
+    jclass java_GLSurfaceView = env->FindClass("android/opengl/GLSurfaceView");
+    java_GLSurfaceView_requestRender = env->GetMethodID(java_GLSurfaceView, "requestRender", "()V");
     methods_initialized = true;
 }
 

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -88,7 +88,7 @@ static void init_methods_cache(JNIEnv *env) {
 
 static void *render_cb(void *data)
 {
-    jobject *glView = (void *)data;
+    jobject *glView = (jobject *)data;
     return env->CallVoidMethod(glView, java_GLSurfaceView_requestRender);
 }
 
@@ -153,7 +153,7 @@ jni_func(void, initGL, jobject view) {
         die("failed to initialize mpv GL context");
     }
 
-    mpv_opengl_cb_set_update_callback(mpv_gl, render_cb, (void *)view);
+    mpv_opengl_cb_set_update_callback(mpv_gl, (mpv_opengl_cb_update_fn)render_cb, (void *)view);
 }
 
 jni_func(void, destroyGL) {

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -87,7 +87,7 @@ static void init_methods_cache(JNIEnv *env) {
     methods_initialized = true;
 }
 
-bool acquire_java_stuff(JavaVM *vm, JNIEnv **env)
+static bool acquire_java_stuff(JavaVM *vm, JNIEnv **env)
 {
     int ret = vm->GetEnv((void**) env, JNI_VERSION_1_6);
     if (ret == JNI_EDETACHED)
@@ -96,15 +96,14 @@ bool acquire_java_stuff(JavaVM *vm, JNIEnv **env)
         return ret == JNI_OK;
 }
 
-static void *render_cb(void *data)
+static void render_cb(void *data)
 {
-    jobject *glView = (jobject *)data;
+    jobject glView = (jobject)data;
     JNIEnv *env;
     if (!acquire_java_stuff(g_vm, &env))
         return;
     env->CallVoidMethod(glView, java_GLSurfaceView_requestRender);
     g_vm->DetachCurrentThread();
-    return;
 }
 
 static void prepare_environment(JNIEnv *env, jobject appctx) {

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -100,6 +100,8 @@ static bool acquire_java_stuff(JavaVM *vm, JNIEnv **env)
 static void render_cb(void *data)
 {
     JNIEnv *env;
+    if (glView == null)
+        return;
     if (!acquire_java_stuff(g_vm, &env))
         return;
     env->CallVoidMethod(glView, java_GLSurfaceView_requestRender);


### PR DESCRIPTION
Lets libmpv control when rendering happens, to avoid GL activity when unnecessary (for example when the player is paused). This would potentially improve battery life and performance.