### PR TITLE
Expand compatibility to include GLES 2.0 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
-    <uses-feature android:glEsVersion="0x00030000" />
+    <uses-feature android:glEsVersion="0x00020000" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -104,8 +104,8 @@ internal class MPVView(context: Context, attrs: AttributeSet) : GLSurfaceView(co
     fun playFile(filePath: String) {
         // Pick an EGLConfig with RGB8 color, 16-bit depth, no stencil,
         // supporting OpenGL ES 3.0 or later backwards-compatible versions.
-        setEGLConfigChooser(8, 8, 8, 0, 16, 0)
         setEGLContextClientVersion(2)
+        setEGLConfigChooser(8, 8, 8, 0, 16, 0)
         val renderer = Renderer(this)
         renderer.setFilePath(filePath)
         setRenderer(renderer)


### PR DESCRIPTION
This is untested (as I don't own any android phones/tablets), but it's something I noticed when I was reviewing the code and researching EGL quirks on Android.