### PR TITLE
x86_64 support

### DIFF
--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -3,6 +3,9 @@ LOCAL_PATH:= $(call my-dir)
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 PREFIX = $(PREFIX64)
 endif
+ifeq ($(TARGET_ARCH_ABI),x86_64)
+PREFIX = $(PREFIX_X64)
+endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libswresample

--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -2,6 +2,9 @@ APP_ABI := armeabi-v7a
 ifneq ($(PREFIX64),)
 APP_ABI += arm64-v8a
 endif
+ifneq ($(PREFIX_X64),)
+APP_ABI += x86_64
+endif
 
 APP_PLATFORM := android-21
 APP_STL := c++_shared


### PR DESCRIPTION
not much to review here, rather just a reminder about x86_64 support (issue #27)
to be merged with [buildscripts sfan5/x86_64](https://github.com/mpv-android/buildscripts/tree/sfan5/x86_64) -> master
(completely optional, build will not fail if you don't bother with compiling for `x86_64`)

/cc @soredake