### PR TITLE
Added an intent filter for streaming URL schemes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,20 @@
             android:launchMode="singleTask"
             android:screenOrientation="sensorLandscape"
             android:theme="@style/AppTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="rtmp" />
+                <data android:scheme="rtmpe" />
+                <data android:scheme="rtmps" />
+                <data android:scheme="rtp" />
+                <data android:scheme="rtsp" />
+                <data android:scheme="mms" />
+                <data android:scheme="mmst" />
+                <data android:scheme="mmsh" />
+                <data android:scheme="udp" />
+            </intent-filter>
             <intent-filter> <!-- MIME type only (e.g. Google Drive) -->
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -287,7 +287,8 @@ class MPVActivity : Activity(), EventObserver, TouchGesturesObserver {
         val filepath = when (data.scheme) {
             "file" -> data.path
             "content" -> openContentFd(data)
-            "http", "https" -> data.toString()
+            "http", "https", "rtmp", "rtmpe", "rtmps", "rtp", "rtsp", "mms", "mmst", "mmsh", "udp"
+            -> data.toString()
             else -> null
         }
 


### PR DESCRIPTION
Added intent filter for `rtmp`, `rtmpe`, `rtmps`, `rtp`, `rtsp`, `mms`, `mmst`, `mmsh`, and `udp` protocols.
This allows URLs with these protocols to be open directly in MPV.