### PR TITLE
Fixed link color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,6 +13,7 @@
         <!-- Need to set this also to style create folder dialog -->
         <item name="alertDialogTheme">@style/FilePickerAlertDialogTheme</item>
         <item name="android:textColorPrimary">@android:color/background_light</item>
+        <item name="android:textColorLink">@android:color/background_light</item>
 
         <!-- If you want to set a specific toolbar theme, do it here -->
         <!-- <item name="nnf_toolbarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item> -->


### PR DESCRIPTION
When clipboard contents with a link were pasted into the **Open URL** dilog, text was almost unreadable (as text color was melding with background color).