### PR TITLE
Audio preferences with audio delay

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -113,6 +113,11 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
             MPVLib.setOptionString("vd-lavc-skiploopfilter", "nonkey")
         }
 
+        if (sharedPreferences.getBoolean("audio_delay", false)) {
+            var audio_delay_offset = sharedPreferences.getString("audio_delay_offset", "0")
+            MPVLib.setOptionString("audio-delay", audio_delay_offset)
+        }
+
         // set options
 
         MPVLib.setOptionString("vo", "gpu")

--- a/app/src/main/java/is/xyz/mpv/SettingsActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/SettingsActivity.kt
@@ -70,6 +70,7 @@ class SettingsActivity : PreferenceActivity() {
         return PreferenceFragment::class.java.name == fragmentName
                 || GeneralPreferenceFragment::class.java.name == fragmentName
                 || VideoPreferenceFragment::class.java.name == fragmentName
+                || AudioPreferenceFragment::class.java.name == fragmentName
                 || DeveloperPreferenceFragment::class.java.name == fragmentName
     }
 
@@ -108,6 +109,25 @@ class SettingsActivity : PreferenceActivity() {
 
             bindPreferenceSummaryToValue(findPreference("video_scale"))
             bindPreferenceSummaryToValue(findPreference("video_downscale"))
+
+        }
+
+        override fun onOptionsItemSelected(item: MenuItem): Boolean {
+            val id = item.itemId
+            if (id == android.R.id.home) {
+                activity.onBackPressed()
+                return true
+            }
+            return super.onOptionsItemSelected(item)
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    class AudioPreferenceFragment : PreferenceFragment() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            addPreferencesFromResource(R.xml.pref_audio)
+            setHasOptionsMenu(true)
 
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="pref_header_audio">Audio</string>
 
     <string name="pref_audio_delay_title">Audio delay</string>
-    <string name="pref_audio_delay_summary">Usefull to compensate for out of sync audio.</string>
+    <string name="pref_audio_delay_summary">Useful to compensate for out of sync audio.</string>
 
     <string name="pref_audio_delay_offset_title">Audio delay offset</string>
     <string name="pref_audio_delay_offset_hint">Offset in seconds (+/-)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,14 @@
     <string name="pref_video_fastdecode_title">Low-quality video decoding</string>
     <string name="pref_video_fastdecode_summary">Trades quality for speed and thus fluent playback.\nREDUCES QUALITY A LOT</string>
 
+    <string name="pref_header_audio">Audio</string>
+
+    <string name="pref_audio_delay_title">Audio delay</string>
+    <string name="pref_audio_delay_summary">Usefull to compensate for out of sync audio.</string>
+
+    <string name="pref_audio_delay_offset_title">Audio delay offset</string>
+    <string name="pref_audio_delay_offset_hint">Offset in seconds (+/-)</string>
+    <string name="pref_audio_delay_offset_summary" translatable="false">%s</string>
 
     <string name="pref_header_developer">Developer</string>
 

--- a/app/src/main/res/xml/pref_audio.xml
+++ b/app/src/main/res/xml/pref_audio.xml
@@ -1,0 +1,18 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="audio_delay"
+        android:summary="@string/pref_audio_delay_summary"
+        android:title="@string/pref_audio_delay_title" />
+
+       <is.xyz.mpv.SummaryEditTextPreference
+       android:defaultValue="0"
+       android:key="audio_delay_offset"
+       android:dependency="audio_delay"
+       android:inputType="numberDecimal|numberSigned"
+       android:summary="@string/pref_audio_delay_offset_summary"
+       android:hint="@string/pref_audio_delay_offset_hint"
+       android:title="@string/pref_audio_delay_offset_title" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/pref_headers.xml
+++ b/app/src/main/res/xml/pref_headers.xml
@@ -11,6 +11,10 @@
         android:title="@string/pref_header_video" />
 
     <header
+        android:fragment="is.xyz.mpv.SettingsActivity$AudioPreferenceFragment"
+        android:title="@string/pref_header_audio" />
+
+    <header
         android:fragment="is.xyz.mpv.SettingsActivity$DeveloperPreferenceFragment"
         android:title="@string/pref_header_developer" />
 


### PR DESCRIPTION
Allows user to set audio-delay via the settings menu. 
Main reason for implementing this was to have a way to compensate for sound delay on bluetooth headset when watching video with hardware decoding enabled.