### PR TITLE
Handle save-position-on-quit manually instead of relying on mpv

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -125,6 +125,7 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
         // Limit demuxer cache to 32 MiB, the default is too high for mobile devices
         MPVLib.setOptionString("demuxer-max-bytes", "${32 * 1024 * 1024}")
         MPVLib.setOptionString("demuxer-max-back-bytes", "${32 * 1024 * 1024}")
+        MPVLib.setOptionString("save-position-on-quit", "no") // done manually by MPVActivity
     }
 
     fun playFile(filePath: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="pref_background_play_summary">When to automatically resume playback in background</string>
     <string name="pref_background_play_default">never</string>
 
+    <string name="pref_save_position_title">Save position on quit</string>
+    <string name="pref_save_position_summary">Remember current playback position on exit. When the same file is played again, seek to the previous position.</string>
+
 
     <string name="pref_header_video">Video</string>
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -42,4 +42,10 @@
         android:entryValues="@array/background_play_values"
         android:title="@string/pref_background_play_title" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="save_position"
+        android:summary="@string/pref_save_position_summary"
+        android:title="@string/pref_save_position_title" />
+
 </PreferenceScreen>


### PR DESCRIPTION
doesn't work correctly otherwise

TODO<i>?</i>: if you kill mpv from the app drawer, the position will not be saved
it's possible to solve this but the solution is hacky/not trivial