### PR TITLE
MPVView: do not set opensles-frames-per-buffer

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -53,13 +53,11 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
                        "(${Build.VERSION.SDK_INT} < ${Build.VERSION_CODES.M})")
         }
 
-        // ao: set optimal buffer size and sample rate for opensles, to get better audio playback
+        // ao: set optimal sample rate for opensles, to get better audio playback
         val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        val framesPerBuffer = am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER)
         val sampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
-        Log.v(TAG, "Device reports optimal frames per buffer $framesPerBuffer sample rate $sampleRate")
+        Log.v(TAG, "Device reports optimal sample rate $sampleRate")
 
-        MPVLib.setOptionString("opensles-frames-per-buffer", framesPerBuffer)
         MPVLib.setOptionString("audio-samplerate", sampleRate)
 
         // set non-complex options

--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -1,6 +1,7 @@
 package `is`.xyz.mpv
 
 import android.content.Context
+import android.media.AudioTrack
 import android.media.AudioManager
 import android.view.SurfaceView
 import android.view.SurfaceHolder
@@ -54,11 +55,11 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
         }
 
         // ao: set optimal sample rate for opensles, to get better audio playback
-        val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        val sampleRate = am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
+        val sampleRate = AudioTrack.getNativeOutputSampleRate(AudioManager.STREAM_MUSIC)
         Log.v(TAG, "Device reports optimal sample rate $sampleRate")
 
-        MPVLib.setOptionString("audio-samplerate", sampleRate)
+        // TODO: better be optional as it may not be ideal if the user switches audio device during playback.
+        MPVLib.setOptionString("audio-samplerate", sampleRate.toString())
 
         // set non-complex options
 


### PR DESCRIPTION
As it is wrong in so many ways:
1. The size per Enqueue() does not affect whether a track would be
   a "fast track" (i.e. fast flag that is always requested by
   OpenSLES by default got accepted) or not.
2. We have not been setting audio-buffer to 0 so the soft buffer
   size has always been the arbitrary generic default, which is
   0.2s as of today.
   Neither would it actually work even if we do though, because
   the value is hardly safe enough to be used in reality.
3. The AudioManager method we have been using provides static, or
   on some devices, garbage value, as in, it does not necessarily
   reflect the buffer size requirement of the current / any audio
   device.
4. In fact, as of today, there isn't exactly any nice method to get
   buffer size requirement.
   getBufferSizeInFrames() / getBufferCapacityInFrames() returns
   value from the HAL when the track is a fast track, which would
   be unsafe for us to use.
   getMinBufferSize() returns value calculated for the deep buffer
   / power saving mixer path which is not used by OpenSLES by
   default (the value is safe to use though).
5. Even if we have means to get correct and safe buffer size
   requirement (like in the AAudio API), the requirement could rise
   drastically when we switch to another audio device (namely
   Bluetooth audio). It means that we would have to restart the
   playback (or re-init the ao) when there's a change of device.
6. As this was not made an option, users cannot easily confirm
   whether it is causing problem in certain scenario.