### PR TITLE
Add optional one-way command server

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/app/src/main/java/is/xyz/mpv/CommandServer.kt
+++ b/app/src/main/java/is/xyz/mpv/CommandServer.kt
@@ -1,0 +1,98 @@
+package `is`.xyz.mpv
+
+import android.net.*
+import android.util.Log
+import java.io.FileDescriptor
+
+import `is`.xyz.mpv.MPVLib
+import android.system.Os
+import android.system.OsConstants
+import kotlinx.coroutines.*
+
+import android.system.ErrnoException
+import java.io.IOException
+
+private val TAG = "mpv"
+
+/* Starts listening for clients at the Unix domain socket abstract address and returns the server's file descriptor, or
+   null if it failed to start. */
+fun commandServerListenAt(address: String): FileDescriptor? {
+    Log.v(TAG, "Command server at '$address' starting")
+    val server = try {
+        LocalServerSocket(address)
+    } catch (e: IOException) {
+        Log.e(TAG, "Command server at '$address' failed to start", e)
+        return null
+    }
+    val fd = server.getFileDescriptor()
+
+    // Loop in a coroutine accepting clients until the file descriptor gets shut down
+    GlobalScope.launch(Dispatchers.IO) {
+        var nClients = 0
+        while (true) {
+            Log.v(TAG, "Command server at '$address' waiting to accept new client")
+            val client = try {
+                server.accept()
+            } catch (e: IOException) {
+                val cause = e.cause
+                if (cause is ErrnoException && cause.errno == OsConstants.EINVAL)  // file descriptor was shut down
+                    break
+                Log.e(TAG, "Command server at '$address' accept failed", e)
+                continue
+            }
+            val iClient = ++nClients
+            Log.v(TAG, "Command server at '$address' client $iClient accepted")
+
+            val fromClient = try {
+                client.setSoTimeout(10000)
+                client.getInputStream().bufferedReader()
+            } catch (e: IOException) {
+                Log.v(TAG, "Command server at '$address' client $iClient closing after setup failure", e)
+                try { client.close() } catch (e: Exception) {}
+                continue
+            }
+
+            // Loop running commands from this client in a coroutine
+            launch {
+                while (isActive) {
+                    val cmd = try {
+                        fromClient.readLine()
+                    } catch (e: IOException) {
+                        if (e.message == "Try again")  // timeout
+                            continue
+                        Log.e(TAG, "Command server at '$address' client $iClient read failed", e)
+                        null
+                    }
+                    if (cmd == null)
+                        break
+
+                    Log.v(TAG, "Command server at '$address' client $iClient running command: $cmd")
+                    MPVLib.commandString(cmd)
+                }
+
+                Log.v(TAG, "Command server at '$address' client $iClient closing")
+                try {
+                    client.close()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Command server at '$address' client $iClient closing failed", e)
+                }
+            }
+        }
+
+        Log.v(TAG, "Command server at '$address' closing")
+        try {
+            server.close()
+        } catch (e: Exception) {
+            Log.e(TAG, "Command server at '$address' closing failed", e)
+        }
+        coroutineContext.cancelChildren()
+    }
+
+    return fd
+}
+
+/* Stops the server listening on fd as well as any of its open client connections. */
+fun commandServerCloseAndClients(fd: FileDescriptor) {
+    Log.v(TAG, "Command server with file descriptor $fd shutting down")
+    Os.shutdown(fd, OsConstants.SHUT_RDWR)
+}

--- a/app/src/main/java/is/xyz/mpv/MPVLib.java
+++ b/app/src/main/java/is/xyz/mpv/MPVLib.java
@@ -25,6 +25,7 @@ public class MPVLib {
      public static native void detachSurface();
 
      public static native void command(String[] cmd);
+     public static native void commandString(String cmd);
 
      public static native int setOptionString(String name, String value);
 

--- a/app/src/main/jni/main.cpp
+++ b/app/src/main/jni/main.cpp
@@ -25,6 +25,7 @@ extern "C" {
     jni_func(void, destroy);
 
     jni_func(void, command, jobjectArray jarray);
+    jni_func(void, commandString, jstring jcmd);
 };
 
 JavaVM *g_vm;
@@ -97,4 +98,15 @@ jni_func(void, command, jobjectArray jarray) {
 
     for (int i = 0; i < len; ++i)
         env->ReleaseStringUTFChars((jstring)env->GetObjectArrayElement(jarray, i), arguments[i]);
+}
+
+jni_func(void, commandString, jstring jcmd) {
+    if (!g_mpv)
+        die("Cannot run command_string: mpv is not initialized");
+
+    const char *cmd = env->GetStringUTFChars(jcmd, NULL);
+
+    mpv_command_string(g_mpv, cmd);
+
+    env->ReleaseStringUTFChars(jcmd, cmd);
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,9 @@
     <string name="pref_advanced_inputconf">Edit input.conf</string>
     <string name="pref_advanced_inputconf_message">You can edit input.conf here, this is mainly useful for TV remotes and keyboards.\n\nImportant: mpv-android has some hardcoded key handlers which can\'t be redefined here, e.g. \'j\' to cycle subtitles.</string>
 
+    <string name="pref_advanced_command_server_title">Enable command server</string>
+    <string name="pref_advanced_command_server_summary">WARNING: any application has complete control of mpv\nListens for connections over a Unix domain socket at the abstract namespace address \"is.xyz.mpv\" and runs lines from connecting clients as mpv commands.</string>
+
     <!-- Strings indirectly related to Settings -->
     <string name="scaler_param1">Param 1:</string>
     <string name="scaler_param2">Param 2:</string>

--- a/app/src/main/res/xml/pref_advanced.xml
+++ b/app/src/main/res/xml/pref_advanced.xml
@@ -22,4 +22,10 @@
         android:title="@string/pref_advanced_version"
         android:negativeButtonText="@null" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="command_server"
+        android:summary="@string/pref_advanced_command_server_summary"
+        android:title="@string/pref_advanced_command_server_title" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Adds a preference to enable a server listening on abstract socket "is.xyz.android" that reads lines from its clients and runs `mpv_command_string(line)` (like the `--input-ipc-server` option in `mpv`).

**Security note:** since it's a socket, there's no restriction on which apps get to pass arbitrary text to `mpv_command_string`. The setting warns about this. I'm not familiar with other Android IPC but am happy to learn and change it.