### PR TITLE
add basic dpad navigation support (AndroidTV)

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -58,8 +58,8 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
     private lateinit var audioManager: AudioManager
 
     private var btnSelected = -1
-    private val colorFocussed = Color.argb(128, 128, 128, 176)
-    private val colorNoFocus = Color.argb(0, 0, 0, 0)
+    private val colorFocussed = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_focussed)
+    private val colorNoFocus = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_nofocus)
 
     private val seekBarChangeListener = object : SeekBar.OnSeekBarChangeListener {
         override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
@@ -129,19 +129,6 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
         controls.prevBtn.setOnLongClickListener { pickPlaylist(); true }
         controls.nextBtn.setOnLongClickListener { pickPlaylist(); true }
-    }
-
-    private fun dpadCenterTriggerAction(btnId: Int) {
-        when (btnId) {
-            controls.playBtn.id -> playPause(controls)
-            controls.cycleAudioBtn.id -> cycleAudio()
-            controls.cycleSubsBtn.id -> cycleSub()
-            controls.cycleDecoderBtn.id -> switchDecoder(controls)
-            controls.cycleSpeedBtn.id -> cycleSpeed(controls)
-            controls.menuBtn.id -> openTopMenu(controls)
-            controls.nextBtn.id -> playlistNext(controls)
-            controls.prevBtn.id -> playlistPrev(controls)
-        }
     }
 
     @SuppressLint("ShowToast")
@@ -436,7 +423,7 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
         // Open, Sesame!
         controls.visibility = View.VISIBLE
-        //top_controls.visibility = View.VISIBLE
+        top_controls.visibility = View.VISIBLE
 
         if (this.statsEnabled) {
             updateStats()
@@ -458,7 +445,7 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
         // use GONE here instead of INVISIBLE (which makes more sense) because of Android bug with surface views
         // see http://stackoverflow.com/a/12655713/2606891
         controls.visibility = View.GONE
-        //top_controls.visibility = View.GONE
+        top_controls.visibility = View.GONE
         statsTextView.visibility = View.GONE
 
         val flags = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE
@@ -545,24 +532,21 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    val childCount = controls_button_group.getChildCount();
+                    val childCount = controls_button_group.childCount;
                     btnSelected = (btnSelected + 1) % childCount
                     updateShowBtnSelected()
                 }
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    val childCount = controls_button_group.getChildCount();
+                    val childCount = controls_button_group.childCount;
                     btnSelected = (childCount + btnSelected - 1) % childCount
                     updateShowBtnSelected()
                 }
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_ENTER || ev.keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    val child = controls_button_group.getChildAt(btnSelected)
-                    if (child != null) {
-                        dpadCenterTriggerAction(child.id)
-                    }
+                    controls_button_group.getChildAt(btnSelected)?.performClick()
                 }
                 return true
             }
@@ -571,16 +555,14 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
     }
 
     fun updateShowBtnSelected () {
-        if (controls_button_group != null) {
-            val childCount = controls_button_group.getChildCount();
-            for (i in 0..childCount) {
-                val child = controls_button_group.getChildAt(i)
-                if (child != null) {
-                    if (i == btnSelected)
-                        child.setBackgroundColor(colorFocussed)
-                    else
-                        child.setBackgroundColor(colorNoFocus)
-                }
+        val childCount = controls_button_group.childCount;
+        for (i in 0..childCount) {
+            val child = controls_button_group.getChildAt(i)
+            if (child != null) {
+                if (i == btnSelected)
+                    child.setBackgroundColor(colorFocussed)
+                else
+                    child.setBackgroundColor(colorNoFocus)
             }
         }
     }
@@ -642,12 +624,12 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
         super.onConfigurationChanged(newConfig)
         val isLandscape = newConfig?.orientation == Configuration.ORIENTATION_LANDSCAPE
 
-        /*// Move top controls so they don't overlap with System UI
+        // Move top controls so they don't overlap with System UI
         if (Utils.hasSoftwareKeys(this)) {
             val lp = RelativeLayout.LayoutParams(top_controls.layoutParams as RelativeLayout.LayoutParams)
             lp.marginEnd = if (isLandscape) Utils.convertDp(this, 48f) else 0
             top_controls.layoutParams = lp
-        }*/
+        }
 
         // Change margin of controls (for the same reason, but unconditionally)
         run {
@@ -940,9 +922,9 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
     private fun updateAudioUI() {
         val audioButtons = arrayOf(R.id.prevBtn, R.id.cycleAudioBtn, R.id.playBtn,
-                R.id.cycleSpeedBtn, R.id.nextBtn, R.id.menuBtn)
+                R.id.cycleSpeedBtn, R.id.nextBtn)
         val videoButtons = arrayOf(R.id.playBtn, R.id.cycleAudioBtn, R.id.cycleSubsBtn,
-                R.id.cycleDecoderBtn, R.id.cycleSpeedBtn, R.id.menuBtn)
+                R.id.cycleDecoderBtn, R.id.cycleSpeedBtn)
 
         val shouldUseAudioUI = isPlayingAudioOnly()
         if (shouldUseAudioUI == useAudioUI)

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -133,12 +133,14 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
     private fun dpadCenterTriggerAction(btnId: Int) {
         when (btnId) {
-            controls.playBtn.id -> player.cyclePause()
+            controls.playBtn.id -> playPause(controls)
             controls.cycleAudioBtn.id -> cycleAudio()
             controls.cycleSubsBtn.id -> cycleSub()
             controls.cycleDecoderBtn.id -> switchDecoder(controls)
             controls.cycleSpeedBtn.id -> cycleSpeed(controls)
             controls.menuBtn.id -> openTopMenu(controls)
+            controls.nextBtn.id -> playlistNext(controls)
+            controls.prevBtn.id -> playlistPrev(controls)
         }
     }
 
@@ -938,7 +940,7 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
     private fun updateAudioUI() {
         val audioButtons = arrayOf(R.id.prevBtn, R.id.cycleAudioBtn, R.id.playBtn,
-                R.id.cycleSpeedBtn, R.id.nextBtn)
+                R.id.cycleSpeedBtn, R.id.nextBtn, R.id.menuBtn)
         val videoButtons = arrayOf(R.id.playBtn, R.id.cycleAudioBtn, R.id.cycleSubsBtn,
                 R.id.cycleDecoderBtn, R.id.cycleSpeedBtn, R.id.menuBtn)
 

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -530,21 +530,25 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    val childCount = controls_button_group.childCount;
+                    val childCount = controls_button_group.childCount + top_controls.childCount;
                     btnSelected = (btnSelected + 1) % childCount
                     updateShowBtnSelected()
                 }
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    val childCount = controls_button_group.childCount;
+                    val childCount = controls_button_group.childCount + top_controls.childCount;
                     btnSelected = (childCount + btnSelected - 1) % childCount
                     updateShowBtnSelected()
                 }
                 return true
             } else if (ev.keyCode == KeyEvent.KEYCODE_ENTER || ev.keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
                 if (ev.action == KeyEvent.ACTION_DOWN) {
-                    controls_button_group.getChildAt(btnSelected)?.performClick()
+                    val childCount = controls_button_group.childCount
+                    if (btnSelected < childCount)
+                        controls_button_group.getChildAt(btnSelected)?.performClick()
+                    else
+                        top_controls.getChildAt(btnSelected - childCount)?.performClick()
                 }
                 return true
             }
@@ -553,16 +557,26 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
     }
 
     fun updateShowBtnSelected () {
-        val colorFocussed = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_focussed)
+        val colorFocused = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_focused)
         val colorNoFocus = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_nofocus)
         val childCount = controls_button_group.childCount;
         for (i in 0..childCount) {
             val child = controls_button_group.getChildAt(i)
             if (child != null) {
                 if (i == btnSelected)
-                    child.setBackgroundColor(colorFocussed)
+                    child.setBackgroundColor(colorFocused)
                 else
                     child.setBackgroundColor(colorNoFocus)
+            }
+            val childCounttop = top_controls.childCount;
+            for (i in 0..childCounttop) {
+                val child = top_controls.getChildAt(i)
+                if (child != null) {
+                    if (i == btnSelected - childCount)
+                        child.setBackgroundColor(colorFocused)
+                    else
+                        child.setBackgroundColor(colorNoFocus)
+                }
             }
         }
     }

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -58,8 +58,6 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
     private lateinit var audioManager: AudioManager
 
     private var btnSelected = -1
-    private val colorFocussed = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_focussed)
-    private val colorNoFocus = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_nofocus)
 
     private val seekBarChangeListener = object : SeekBar.OnSeekBarChangeListener {
         override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
@@ -555,6 +553,8 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
     }
 
     fun updateShowBtnSelected () {
+        val colorFocussed = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_focussed)
+        val colorNoFocus = ContextCompat.getColor(applicationContext, R.color.tint_btn_bg_nofocus)
         val childCount = controls_button_group.childCount;
         for (i in 0..childCount) {
             val child = controls_button_group.getChildAt(i)
@@ -585,6 +585,12 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
             KeyEvent.KEYCODE_HEADSETHOOK -> player.cyclePause()
             KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK -> cycleAudio()
             KeyEvent.KEYCODE_INFO -> toggleControls()
+
+            // AndroidTV
+            KeyEvent.KEYCODE_MENU -> openTopMenu(controls)
+            KeyEvent.KEYCODE_GUIDE -> openTopMenu(controls)
+            KeyEvent.KEYCODE_ENTER -> player.cyclePause()
+            KeyEvent.KEYCODE_DPAD_CENTER -> player.cyclePause()
 
             // overrides a default binding:
             KeyEvent.KEYCODE_MEDIA_PAUSE -> player.paused = true

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -153,17 +153,6 @@
                 android:text=".."
                 android:textColor="@android:color/white" />
 
-            <ImageButton
-                android:id="@+id/menuBtn"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_settings_black_24dp"
-                android:onClick="openTopMenu"
-                android:text="..."
-                android:textColor="@android:color/white"
-                android:tint="@color/tint_normal" />
-
         </LinearLayout>
     </LinearLayout>
 
@@ -197,7 +186,6 @@
         android:textStyle="bold"
         android:visibility="gone" />
 
-    <!--
     <LinearLayout
         android:id="@+id/top_controls"
         style="?android:attr/buttonBarStyle"
@@ -220,6 +208,5 @@
             android:tint="@color/tint_normal" />
 
     </LinearLayout>
-    -->
 
 </RelativeLayout>

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -153,6 +153,17 @@
                 android:text=".."
                 android:textColor="@android:color/white" />
 
+            <ImageButton
+                android:id="@+id/menuBtn"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_settings_black_24dp"
+                android:onClick="openTopMenu"
+                android:text="..."
+                android:textColor="@android:color/white"
+                android:tint="@color/tint_normal" />
+
         </LinearLayout>
     </LinearLayout>
 
@@ -186,6 +197,7 @@
         android:textStyle="bold"
         android:visibility="gone" />
 
+    <!--
     <LinearLayout
         android:id="@+id/top_controls"
         style="?android:attr/buttonBarStyle"
@@ -208,5 +220,6 @@
             android:tint="@color/tint_normal" />
 
     </LinearLayout>
+    -->
 
 </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,7 +8,7 @@
     <color name="tint_disabled">#3c3c3c</color>
 
     <color name="tint_btn_bg_nofocus">#00000000</color>
-    <color name="tint_btn_bg_focussed">#807F7FB2</color>
+    <color name="tint_btn_bg_focused">#807F7FB2</color>
 
     <!-- 12% black in LIGHT THEME -->
     <color name="nnf_light_separator_color">#1e000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,8 +7,8 @@
     <color name="tint_normal">#ffffff</color>
     <color name="tint_disabled">#3c3c3c</color>
 
-    <color name="tint_btn_bg_focussed">#00000000</color>
-    <color name="tint_btn_bg_nofocus">#7f7f7f1a</color>
+    <color name="tint_btn_bg_nofocus">#00000000</color>
+    <color name="tint_btn_bg_focussed">#807F7FB2</color>
 
     <!-- 12% black in LIGHT THEME -->
     <color name="nnf_light_separator_color">#1e000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,9 @@
     <color name="tint_normal">#ffffff</color>
     <color name="tint_disabled">#3c3c3c</color>
 
+    <color name="tint_btn_bg_focussed">#00000000</color>
+    <color name="tint_btn_bg_nofocus">#7f7f7f1a</color>
+
     <!-- 12% black in LIGHT THEME -->
     <color name="nnf_light_separator_color">#1e000000</color>
     <!-- 12% white in BLACK THEME -->


### PR DESCRIPTION
- add basic dpad navigation support for Android TV

DPAD_UP and DOWN both control activation and deactivation of the dpad navigation with the interceptDpad function.
DPAD_LEFT, RIGHT and CENTER handle the button selection and trigger, but they are only overridden when dpad navigation is enabled.
Also the callback to auto hide the controls is disabled as long as dpad navigation is active, only.