### PR TITLE
MPVActivity: Add pref to extend video in the cutout area

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -343,6 +343,17 @@ class MPVActivity : Activity(), MPVLib.EventObserver, TouchGesturesObserver {
 
         if (this.statsOnlyFPS)
             statsTextView.setTextColor((0xFF00FF00).toInt()) // green
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val displayInCutout = prefs.getBoolean("display_in_cutout", false);
+            var lp = window.attributes
+            if (displayInCutout) {
+                lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            } else {
+                lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+            }
+            window.attributes = lp
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <string name="pref_auto_rotation_summary">Decide which orientation mpv will play landscape or portrait videos in</string>
     <string name="pref_auto_rotation_default" translatable="false">auto</string>
 
+    <string name="pref_display_in_cutout_title">Extend video into the notch/cutout area</string>
+
 
     <string name="pref_header_video">Video</string>
 
@@ -101,8 +103,6 @@
     <string name="pref_video_tscale_title">Temporal interpolation filter</string>
     <string name="pref_video_tscale_summary">Select the filter used for interpolating the temporal axis (frames)</string>
     <string name="pref_video_tscale_message">These settings only take effect if Interpolation is enabled above.</string>
-
-
 
     <string name="pref_video_fastdecode_title">Low-quality video decoding</string>
     <string name="pref_video_fastdecode_summary">Trades quality for speed and thus fluent playback.\n<b>REDUCES QUALITY A LOT</b></string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -56,4 +56,10 @@
         android:entryValues="@array/auto_rotation_values"
         android:title="@string/pref_auto_rotation_title" />
 
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="display_in_cutout"
+        android:summary=""
+        android:title="@string/pref_display_in_cutout_title" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Many newer Android devices feature a notch or hole-punch camera, and by
default, Android will size landscape windows so that they don't extend
into the cutout area. For video playback, it is common to support
displaying the video over the entire screen, regardless of the cutout,
so let's add that option.

I've defaulted this to off, but maybe it should be on.