### PR TITLE
FilePicker: Draw behind navigation bar in the modern style

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MainActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MainActivity.kt
@@ -6,12 +6,16 @@ import android.os.Bundle
 import android.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatActivity
 import android.text.InputType
+import android.view.View
 import android.view.Menu
 import android.view.MenuItem
+import android.view.WindowManager
 import android.widget.EditText
+import android.widget.RelativeLayout
 import android.os.Build
 import android.os.Environment
 import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
 
 import `is`.xyz.filepicker.AbstractFilePickerFragment
 import `is`.xyz.mpv.config.SettingsActivity
@@ -23,9 +27,31 @@ class MainActivity : AppCompatActivity(), AbstractFilePickerFragment.OnFilePicke
     private var fragment: MPVFilePickerFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Set the system UI to act as if the nav bar is hidden, so that we can
+        // draw behind it. STABLE flag is historically recommended but was
+        // deprecated in API level 30, so probably not strictly necessary, but
+        // cargo-culting is fun.
+        window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                                              View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         fragment = supportFragmentManager.findFragmentById(R.id.file_picker_fragment) as MPVFilePickerFragment
+
+        // With the app acting as if the navbar is hidden, we need to
+        // account for it outselves. We want the recycler to directly
+        // take the system UI padding so that we can tell it to draw
+        // into the padded area while still respecting the padding for
+        // input.
+        val layout: RelativeLayout = findViewById(R.id.main_layout)
+        val recycler: RecyclerView = layout.findViewById(android.R.id.list)
+        recycler.setOnApplyWindowInsetsListener { view, insets ->
+            view.setPadding(insets.systemWindowInsetLeft,
+                            insets.systemWindowInsetTop,
+                            insets.systemWindowInsetRight,
+                            insets.systemWindowInsetBottom)
+            insets
+        }
 
         // TODO: rework or remove this setting
         val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/main_layout"
     tools:context="is.xyz.mpv.MainActivity">
     <fragment android:name="is.xyz.mpv.MPVFilePickerFragment"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/nnf_fragment_filepicker.xml
+++ b/app/src/main/res/layout/nnf_fragment_filepicker.xml
@@ -11,12 +11,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!--
+      We configure the recycler to not clip to padding as we want it to
+      draw into the padded area behind the navigation bar.	
+     -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:descendantFocusability="afterDescendants"
         android:focusable="true"
+        android:clipToPadding="false"
         tools:listitem="@layout/nnf_filepicker_listitem_dir"/>
 
     <FrameLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,6 +37,8 @@
 
         <!-- If you want to set a specific toolbar theme, do it here -->
         <!-- <item name="nnf_toolbarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item> -->
+
+        <item name="android:windowTranslucentNavigation">true</item>
     </style>
     <style name="FilePickerDialogTheme" parent="Theme.AppCompat.Dialog">
         <!-- identical to FilePickerTheme, just as a dialog -->


### PR DESCRIPTION
This is surprisingly involved for what's supposed to be the preferred
style in modern Android apps.

1) Set View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION on the system UI.
   This tells the app to draw itself as if the system UI was hidden,
   even if it is not.

2) The navigation bar needs to be transparent/translucent for this to
   be visible. That can be done by setting an alpha value for the
   navigation bar colour, or simply by setting the translucent nav
   bar attribute on the file picker. As we don't care about having
   a special colour, just mark it as translucent.

3) At this stage, the file picker is being drawn behind the navigation
   bar _and_ the status bar. The action bar is drawn correctly as we
   are, I think, using a particular action bar widget that the OS
   positions below the status bar regardless of the flags.

4) We can fix this by applying the window insets to the recycler view.
   The insets are the padding that would be applied by the OS if we
   didn't get the flag, and now we need to apply it ourselves. Applying
   these to the recycler view fixes the drawing under the status bar,
   but also stops us drawing under the navigation bar, which is what
   we were trying to achieve. We might be tempted _not_ to apply the
   bottom padding, but doing that means the last item in the list may
   end up completely behind the bar, especially of three button
   nav is being used. We need the recycler to scroll the last item up
   past the navigation, while still drawing behind it.

5) To fix that, we tell the recycler view not to clip to the padding,
   so it draws into the padding area, but places the interactive
   elements to respect the padding. This means it will scroll the last
   item up as we need it to. The recycler is also technically rendering
   under the status bar but as that's opaque, it doesn't matter.

6) Finally, we need to also apply the left/right padding for landscape
   mode so that we don't incorrectly draw under a three button nav bar.