### PR TITLE
TouchGestures: Add a gesture to toggle Pan/Scan zooming

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -1478,6 +1478,8 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
                 fadeGestureText()
             }
             PropertyChange.PlayPause -> player.cyclePause()
+            PropertyChange.PanScan -> MPVLib.command(arrayOf("cycle-values", "panscan", "1.0", "0.0"))
+
         }
     }
 

--- a/app/src/main/java/is/xyz/mpv/TouchGestures.kt
+++ b/app/src/main/java/is/xyz/mpv/TouchGestures.kt
@@ -16,6 +16,7 @@ enum class PropertyChange {
 
     SeekFixed, // (tap gesture)
     PlayPause, // (tap gesture)
+    PanScan,   // (tap gesture)
 }
 
 interface TouchGesturesObserver {
@@ -172,7 +173,8 @@ class TouchGestures(private val observer: TouchGesturesObserver) {
         )
         val map2 = mapOf(
                 "seek" to PropertyChange.SeekFixed,
-                "playpause" to PropertyChange.PlayPause
+                "playpause" to PropertyChange.PlayPause,
+                "panscan" to PropertyChange.PanScan,
         )
 
         gestureHoriz = map[get("gesture_horiz", R.string.pref_gesture_horiz_default)] ?: State.Down

--- a/app/src/main/res/values-ja/arrays.xml
+++ b/app/src/main/res/values-ja/arrays.xml
@@ -38,5 +38,6 @@
         <item>なし</item>
         <item>シーク</item>
         <item>再生/一時停止</item>
+        <item>ズーム</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -115,10 +115,12 @@
         <item>None</item>
         <item>Seek</item>
         <item>Play/Pause</item>
+        <item>Zoom</item>
     </string-array>
     <string-array name="tap_gestures_values" translatable="false">
         <item>none</item>
         <item>seek</item>
         <item>playpause</item>
+        <item>panscan</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Most modern Android phones have very wide screens and media players
often offer the ability to zoom to remove black bars. mpv's panscan
property does this, so let's add a gesture to allow toggling it.