### PR TITLE
Added sftp protocol scheme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,8 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:scheme="ftp" />
+                <data android:scheme="sftp" />
                 <data android:host="*" />
                 <data android:mimeType="video/*" />
                 <data android:mimeType="audio/*" />
@@ -82,6 +84,8 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
+                <data android:scheme="ftp" />
+                <data android:scheme="sftp" />
                 <data android:host="*" />
                 <!-- the duplicate patterns below work around an Android bug: -->
                 <!-- http://stackoverflow.com/questions/3400072/#answer-8599921 -->


### PR DESCRIPTION
This change should allow external tools who are prompting for sftp:// to
find mpv as a potential target.

This specific use case has appeared in MiXplorer where it prompted for
sftp:// and later shares a http:// link to the actual content.

I haven't tested if this is the problem because I can't build it on my machine atm. But I strongly suspect that this is the issue.