### PR TITLE
Enable fat LTO with dav1d for faster AV1 decode

### DIFF
--- a/buildscripts/scripts/dav1d.sh
+++ b/buildscripts/scripts/dav1d.sh
@@ -16,7 +16,7 @@ fi
 unset CC CXX # meson wants these unset
 
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	-Denable_tests=false
+	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install


### PR DESCRIPTION
This enables building the libdav1d decoder utilizing fat LTO.
Unlike with GCC where any kind of LTO reduces decode performance, building dav1d with Clang and fat LTO increases performance considerably on desktop x86_64 CPUs, increasing performance by as much as 10-12% in difficult scenarios, with an average performance improvement of 8%.

I've also tested this on an ARM64 CPU(Snapdragon 730), which gives a decoding performance improvement of around 5-8% in most scenarios, with some edge cases performing slightly better than these figures. Older ARM64 and ARM32 chips seem to get similar improvements according to anecdotal evidence.

Building the library using fat LTO requires these options to be enabled: `Db_lto=true -Dstack_alignment=16`.
`-Dstack_alignment=16` is necessary to get the build process working, which is why it was included.