### PR TITLE
Audio 3d

### DIFF
--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -58,6 +58,14 @@ LOCAL_EXPORT_C_INCLUDES := $(PREFIX)/include
 include $(PREBUILT_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := libmysofa
+LOCAL_SRC_FILES := $(PREFIX)/lib/$(LOCAL_MODULE).so
+LOCAL_EXPORT_C_INCLUDES := $(PREFIX)/include
+include $(PREBUILT_SHARED_LIBRARY)
+
+
+
+include $(CLEAR_VARS)
 
 LOCAL_MODULE    := libplayer
 LOCAL_CFLAGS    := -Werror

--- a/buildscripts/buildall.sh
+++ b/buildscripts/buildall.sh
@@ -7,7 +7,7 @@ cleanbuild=0
 nodeps=0
 clang=1
 target=mpv-android
-arch=armv7l
+export arch=armv7l
 
 getdeps () {
 	varname="dep_${1//-/_}[*]"
@@ -132,6 +132,7 @@ while [ $# -gt 0 ]; do
 		--arch)
 		shift
 		arch=$1
+        
 		;;
 		-h|--help)
 		usage

--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -11,14 +11,15 @@ v_harfbuzz=3.0.0
 v_fribidi=1.0.11
 v_freetype=2-11-0
 v_mbedtls=2.27.0
-
+v_libmysofa=1.2.1
 
 ## Dependency tree
 # I would've used a dict but putting arrays in a dict is not a thing
 
 dep_mbedtls=()
 dep_dav1d=()
-dep_ffmpeg=(mbedtls dav1d)
+dep_libmysofa=()
+dep_ffmpeg=(mbedtls dav1d libmysofa)
 dep_freetype2=()
 dep_fribidi=()
 dep_harfbuzz=()
@@ -34,4 +35,4 @@ dep_mpv_android=(mpv)
 v_travis_ffmpeg=75001ae8440d819d23443709091fca4c39e395a1
 
 # filename used to uniquely identify a build prefix
-travis_tarball="prefix-ndk-${v_ndk}-lua-${v_lua}-harfbuzz-${v_harfbuzz}-fribidi-${v_fribidi}-freetype-${v_freetype}-mbedtls-${v_mbedtls}-ffmpeg-${v_travis_ffmpeg}.tgz"
+travis_tarball="prefix-ndk-${v_ndk}-lua-${v_lua}-harfbuzz-${v_harfbuzz}-fribidi-${v_fribidi}-freetype-${v_freetype}-mbedtls-${v_mbedtls}-libmysofa-${v_libmysofa}-ffmpeg-${v_travis_ffmpeg}.tgz"

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -17,6 +17,13 @@ fi
 # dav1d
 [ ! -d dav1d ] && git clone https://code.videolan.org/videolan/dav1d.git
 
+# libmysofa
+if [ ! -d libmysofa ]; then
+    mkdir libmysofa
+    $WGET https://github.com/hoene/libmysofa/archive/refs/tags/v${v_libmysofa}.tar.gz -O - | \
+        tar -xz -C libmysofa --strip-components=1
+fi
+
 # ffmpeg
 if [ ! -d ffmpeg ]; then
 	git clone https://github.com/FFmpeg/FFmpeg ffmpeg

--- a/buildscripts/include/path.sh
+++ b/buildscripts/include/path.sh
@@ -26,3 +26,5 @@ fi
 toolchain=$(echo "$DIR/sdk/android-ndk-r23/toolchains/llvm/prebuilt/"*)
 export PATH="$toolchain/bin:$DIR/sdk/android-ndk-r23:$DIR/sdk/bin:$PATH"
 export ANDROID_HOME="$DIR/sdk/android-sdk-$os"
+export ANDROID_NDK="$DIR/sdk/android-ndk-r23/"
+

--- a/buildscripts/scripts/ffmpeg.sh
+++ b/buildscripts/scripts/ffmpeg.sh
@@ -28,7 +28,8 @@ cpuflags=
 	--extra-cflags="-I$prefix_dir/include $cpuflags" --extra-ldflags="-L$prefix_dir/lib" \
 	--disable-static --enable-shared --enable-{gpl,version3} \
 	--pkg-config=pkg-config --disable-{stripping,doc,programs} \
-	--disable-{muxers,encoders,devices} --enable-encoder=mjpeg,png
+	--disable-{muxers,encoders,devices} --enable-encoder=mjpeg,png \
+    --enable-libmysofa
 
 make -j$cores
 make DESTDIR="$prefix_dir" install

--- a/buildscripts/scripts/libmysofa.sh
+++ b/buildscripts/scripts/libmysofa.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+. ../../include/path.sh
+
+
+#setup architecture to ABI mapping
+declare -A arch2abi
+arch2abi=(['armv7l']='armeabi-v7a' ['arm64']='arm64-v8a' ['x86']='x86' ['x86_64']='x86_64')
+
+function run_cmake () {
+    
+    if [[ ! -f build/Makefile ]]; then
+        
+        cmake \
+            -DCMAKE_SYSTEM_NAME=Android \
+            -DCMAKE_ANDROID_ARCH_ABI="${arch2abi[$arch]}" \
+            -DCMAKE_ANDROID_NDK="$ANDROID_NDK" \
+            -DCMAKE_INSTALL_PREFIX="$prefix_dir" \
+            -DCMAKE_C_FLAGS="-I${prefix_dir}/include" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-L${prefix_dir}/lib" \
+            -DBUILD_TESTS=OFF -D BUILD_STATIC_LIBS=OFF -B build
+    fi
+}
+
+function build_libmysofa () {
+    run_cmake
+    cmake  --build build -v --target all install
+}
+
+function clean_libmysofa () {
+    if [[ -f build/Makefile ]]; then
+        rm -rf build
+    fi
+   
+}
+
+
+if [ "$1" == "build" ]; then
+    build_libmysofa
+elif [ "$1" == "clean" ]; then
+	clean_libmysofa
+	exit 0
+else
+	exit 255
+fi
+
+
+
+
+


### PR DESCRIPTION
This branch contains support for 3d audio(libmysofa based). 

cmake 3.22.0 is required due to recent changes to Android NDK afaik.

To test it out, add these lines to mpv.conf

`ad-lavc-downmix=no`

`af-add=lavfi=[sofalizer=sofa=/storage/Downloads/ClubFritz6.sofa:radius=3:gain=0:elevation=0:interpolate=1]`

There are several sofa files at [Sofaconventions.org](https://www.sofaconventions.org/mediawiki/index.php/Files), but the best sounding is ClubFritz6.sofa available at [ClubFritz](http://sofacoustics.org/data/database/clubfritz/)

Copy the .sofa file to a suitable location on your phone and then play some multi-channel audio or video file to feel the effect. If the volume is too low, adjust the gain value(dB). Details about the filter is available at [FFmpeg Filters](https://ffmpeg.org/ffmpeg-filters.html#sofalizer)

