### PR TITLE
Horizontal deadzone to avoid conflict with A10+ Back gesture.

### DIFF
--- a/app/src/main/java/is/xyz/mpv/TouchGestures.kt
+++ b/app/src/main/java/is/xyz/mpv/TouchGestures.kt
@@ -205,7 +205,10 @@ class TouchGestures(private val observer: TouchGesturesObserver) {
             }
             MotionEvent.ACTION_DOWN -> {
                 // deadzone on top/bottom
-                if (e.y < height * DEADZONE / 100 || e.y > height * (100 - DEADZONE) / 100)
+                if (e.y < height * DEADZONE / 100
+                    || e.y > height * (100 - DEADZONE) / 100
+                    || e.x < width * DEADZONE / 100
+                    || e.x > width * (100 - DEADZONE) / 100)
                     return false
                 processTap(point)
                 initialPos = point


### PR DESCRIPTION
If Hold to seek is enabled, attempting to exit fullscreen mode with Android 10+ Back gesture will result in MPV seeking the video. As a workaround, users may first swipe from top/bottom to exit fullscreen mode, then swipe from left/right side for back gesture, but it's definitely not as intuitive as double swiping back gesture. Similar to a107eff.