### PR TITLE
MPVActivity: Pass content uri to libmpv.

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -909,7 +909,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             }
         } catch(e: Exception) { }
         // Else, pass the fd to mpv
-        return "fdclose://${fd}"
+        return "fdclose://${fd}/p/${uri}"
     }
 
     private fun parseIntentExtras(extras: Bundle?) {


### PR DESCRIPTION
Pass content uri to libmpv via the fdclose protocol, which will treat it as a path.

Do not merge until [this](https://github.com/mpv-player/mpv/pull/10659) upstream pr has passed.

close:
  - #542
  - #578
  - #599

_Known issue: Remember playback position doesn't work with mpv-android's built-in document picker, but still displays titles correctly._

_Here is an [artifact](https://github.com/YanceyChiew/mpv-andorid-temp/actions/runs/3086478625) available for temporary testing._