### PR TITLE
Build fdk-aac

### DIFF
--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -21,7 +21,8 @@ v_mbedtls=2.28.1
 
 dep_mbedtls=()
 dep_dav1d=()
-dep_ffmpeg=(mbedtls dav1d)
+dep_fdkaac=()
+dep_ffmpeg=(mbedtls dav1d fdkaac)
 dep_freetype2=()
 dep_fribidi=()
 dep_harfbuzz=()

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -50,6 +50,13 @@ if [ ! -d lua ]; then
 		tar -xz -C lua --strip-components=1
 fi
 
+#fdkaac
+#[ ! -d fdkaac ] && git clone https://github.com/mstorsjo/fdk-aac.git fdkaac
+
+# fdkaac free
+[ ! -d fdkaac ] && git clone --branch fedora git://people.freedesktop.org/~wtay/fdk-aac fdkaac
+
+
 # mpv
 [ ! -d mpv ] && git clone https://github.com/mpv-player/mpv
 

--- a/buildscripts/scripts/fdkaac.sh
+++ b/buildscripts/scripts/fdkaac.sh
@@ -38,14 +38,7 @@ echo "void android_errorWriteLog(int i, const char *string){}" > libSBRdec/inclu
 --disable-shared \
 --disable-frontend \
 --enable-static
-#--prefix="$prefix_dir" ##disable for arm32 builds
 
 make clean
 make -j$cores 
 make DESTDIR="$prefix_dir" install 
-#unset CC CXX # meson wants these unset
-#meson $build --cross-file "$prefix_dir"/crossfile.txt \
-#	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
-
-#ninja -C $build -j$cores
-#DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/fdkaac.sh
+++ b/buildscripts/scripts/fdkaac.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+. ../../include/path.sh
+
+build=_build$ndk_suffix
+#
+if [ "$1" == "build" ]; then
+	true
+elif [ "$1" == "clean" ]; then
+	rm -rf $build
+	exit 0
+else
+	exit 255
+fi
+
+
+case "$ndk_triple" in
+	arm*)
+	target=arm-linux
+	;;
+	aarch64*)
+	target=aarch64-linux
+	;;
+	i686*)
+	target=linux-x86-clang
+	;;
+	x86_64*)
+	target=linux-x86_64-clang
+	;;
+esac
+
+mkdir -p libSBRdec/include/log/
+echo "void android_errorWriteLog(int i, const char *string){}" > libSBRdec/include/log/log.h
+
+./autogen.sh
+
+./configure --host=$target \
+--disable-shared \
+--disable-frontend \
+--enable-static
+#--prefix="$prefix_dir" ##disable for arm32 builds
+
+make clean
+make -j$cores 
+make DESTDIR="$prefix_dir" install 
+#unset CC CXX # meson wants these unset
+#meson $build --cross-file "$prefix_dir"/crossfile.txt \
+#	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
+
+#ninja -C $build -j$cores
+#DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/ffmpeg.sh
+++ b/buildscripts/scripts/ffmpeg.sh
@@ -27,7 +27,7 @@ cpuflags=
 	--arch=${ndk_triple%%-*} --cpu=$cpu --pkg-config=pkg-config \
 	--extra-cflags="-I$prefix_dir/include $cpuflags" --extra-ldflags="-L$prefix_dir/lib" \
 	--enable-{jni,mediacodec,mbedtls,libdav1d} --disable-vulkan \
-	--disable-static --enable-shared --enable-{gpl,version3} \
+	--disable-static --enable-shared --enable-{gpl,nonfree,version3} --enable-libfdk-aac \
 	--disable-{stripping,doc,programs} \
 	--disable-{muxers,encoders,devices} --enable-encoder=mjpeg,png
 


### PR DESCRIPTION
My main use for this was to build my own fdk-aac for support for other aac codecs, but libfdk-aac has good performance anyways. 

I have it set to only use gnu compatible fdk-aac (at least according to RHEL anyways). So while `--non-free` is toggled, it should still only be compiling against gnu compatible and should be fine for distribution.

I'm not sure if merely toggling `--non-free` makes ffmpeg unlicensed. 