### PR TITLE
support for passing some common mpv options as intent extras

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -924,6 +924,18 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
                 onloadCommands.add(arrayOf("sub-add", subfile, flag))
             }
         }
+        if (extras.containsKey("sub-file")) {
+            val subFile: String = extras.getString("sub-file", "Default")
+            Log.v(TAG, "intentExtras: 'sub-file' will be set to '$subFile'")
+            onloadCommands.add(arrayOf("sub-add", subFile, "select"))
+        }
+        if (extras.containsKey("sub-files")) {
+            // when used from browser intent uri, this will split urls if they contain urlencoded semicolons
+            val subFiles: List<String> = extras.getString("sub-files", "Default").split(";")
+            Log.v(TAG, "intentExtras: 'sub-files' will be added. Items are separated by ';'")
+            for (sub in subFiles)
+                onloadCommands.add(arrayOf("sub-add", sub, "auto"))
+        }
         if (extras.getInt("position", 0) > 0) {
             val pos = extras.getInt("position", 0) / 1000f
             onloadCommands.add(arrayOf("set", "start", pos.toString()))
@@ -947,6 +959,21 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             val tlsVerify: String = extras.getString("tls-verify", "Default")
             Log.v(TAG, "intentExtras: 'tls-verify' will be set to '$tlsVerify'")
             onloadCommands.add(arrayOf("set", "tls-verify", tlsVerify))
+        }
+        if (extras.containsKey("resume-playback")) {
+            val resumePlayback: String = extras.getString("resume-playback", "Default")
+            Log.v(TAG, "intentExtras: 'resume-playback' will be set to '$resumePlayback'")
+            onloadCommands.add(arrayOf("set", "resume-playback", resumePlayback))
+        }
+        if (extras.containsKey("force-seekable")) {
+            val forceSeekable: String = extras.getString("force-seekable", "Default")
+            Log.v(TAG, "intentExtras: 'force-seekable' will be set to '$forceSeekable'")
+            onloadCommands.add(arrayOf("set", "force-seekable", forceSeekable))
+        }
+        if (extras.containsKey("cookies")) {
+            val cookies: String = extras.getString("cookies", "Default")
+            Log.v(TAG, "intentExtras: 'cookies' will be set to '$cookies'")
+            onloadCommands.add(arrayOf("set", "cookies", cookies))
         }
         // setting title via onloadCommands doesnt work, needs to be set earlier
         if (extras.containsKey("title")) {

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -934,17 +934,17 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         // support some common mpv options
         var intentOptions = mutableListOf<Pair<String, String>>()
         val allowedIntentOptions = arrayOf(
-            "sub-file",
-            "sub-files",
-            "http-header-fields",
-            "user-agent",
-            "referrer",
-            "media-title",
-            "force-media-title",
-            "tls-verify",
-            "resume-playback",
-            "force-seekable",
-            "cookies"
+            "--sub-file",
+            "--sub-files",
+            "--http-header-fields",
+            "--user-agent",
+            "--referrer",
+            "--media-title",
+            "--force-media-title",
+            "--tls-verify",
+            "--resume-playback",
+            "--force-seekable",
+            "--cookies"
         )
         for (option in allowedIntentOptions) {
             if (extras.containsKey(option)) {
@@ -956,7 +956,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         // also support title, standard among other android players
         if (extras.containsKey("title")) {
             extras.getString("title")?.let { value ->
-                intentOptions.add(Pair("force-media-title", value))
+                intentOptions.add(Pair("--force-media-title", value))
             }
         }
 

--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -13,12 +13,13 @@ import kotlin.math.abs
 import kotlin.reflect.KProperty
 
 internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(context, attrs), SurfaceHolder.Callback {
-    fun initialize(configDir: String) {
+    fun initialize(configDir: String, intentExtrasFile: String) {
         MPVLib.create(this.context)
         MPVLib.setOptionString("config", "yes")
         MPVLib.setOptionString("config-dir", configDir)
         initOptions() // do this before init() so user-supplied config can override our choices
         MPVLib.init()
+        MPVLib.setOptionString("include", intentExtrasFile)
         // certain options are hardcoded:
         MPVLib.setOptionString("save-position-on-quit", "no")
         MPVLib.setOptionString("force-window", "no")

--- a/docs/default.css
+++ b/docs/default.css
@@ -16,6 +16,9 @@ pre {
 	white-space: pre;
 	display: block;
 	padding: 12px;
+
+	overflow-x: auto;
+	white-space: pre-wrap;
 }
 code {
 	color: #e43;

--- a/docs/intent.html
+++ b/docs/intent.html
@@ -40,6 +40,12 @@
 			<code>subs.enable</code> (ParcelableArray of Uri): specifies which of the subtitles should be selected by default, subset of previous array
 		</li>
 		<li>
+			<code>sub-file</code> (String): add one subtitle file to the list of external subtitles. This subtitle file is displayed by default
+		</li>
+		<li>
+			<code>sub-files</code> (String): add multiple subtitle files separated by ;
+		</li>
+		<li>
 			<code>position</code> (Int): starting point of video playback in milliseconds
 		</li>
 		<li>
@@ -58,6 +64,17 @@
 		</li>
 		<li>
 			<code>title</code> (String): specify title to be used instead of filename
+		</li>
+		<li>
+			<code>resume-playback</code> (String): specify if playback time should be resotred with "yes" or "no"
+		</li>
+		<li>
+			<code>force-seekable</code> (String): If the player thinks that the media is not seekable (e.g. playing from a pipe,
+	or it's an http stream with a server that doesn't support range requests), seeking will be disabled.
+	This option can forcibly enable it. For seeks within the cache, there's a good chance of success.
+		</li>
+		<li>
+			<code>cookies</code> (String): support cookies when making HTTP requests. Disabled by default.
 		</li>
 	</ul>
 

--- a/docs/intent.html
+++ b/docs/intent.html
@@ -42,6 +42,23 @@
 		<li>
 			<code>position</code> (Int): starting point of video playback in milliseconds
 		</li>
+		<li>
+			<code>user-agent</code> (String): specify user agent for HTTP streaming
+		</li>
+		<li>
+			<code>referrer</code> (String): specify a referrer path or URL for HTTP requests
+		</li>
+		<li>
+			<code>http-header-fields</code> (String): set custom HTTP fields when accessing HTTP stream. Fields are separated by commas <br>
+			Escape commas inside a field's value with a backslash 
+			<pre>Accept: */*,Accept-Language: en-RO\,en;q=0.9\,ro-RO;q=0.8\,ro;q=0.7\,en-US;q=0.6 </pre>
+		</li>
+		<li>
+			<code>tls-verify</code> (String): verify peer certificates when using TLS 
+		</li>
+		<li>
+			<code>title</code> (String): specify title to be used instead of filename
+		</li>
 	</ul>
 
 	<details>
@@ -54,9 +71,16 @@ intent.setPackage("is.xyz.mpv")
 startActivity(intent)</pre>
 		<h5>HTML (Chrome)</h5>
 		<pre>&lt;a href="intent://example.org/media.png#Intent;type=video/any;package=is.xyz.mpv;scheme=https;end;"&gt;Click me&lt;/a&gt;</pre>
+		<pre>&lt;a href="intent:https://example.com/abc#Intent;package=is.xyz.mpv;S.title=abc;S.http-header-fields=Cookie: key1=val1%3b 
+key2=val2,Accept: */*,Accept-Language: en-RO%5c,en%3bq=0.9%5c,ro-RO%3bq=0.8%5c,ro%3bq=0.7%5c,en-US%3bq=0.6;end;"&gt;Click me&lt;/a&gt;</pre>
+		<h4>Notice that semicolons, backslashes must be urlencoded (; => %3b and \ => %5c)</h4>
 		<h5>Command line (e.g. adb or Termux)</h5>
 		<pre>am start -a android.intent.action.VIEW -t video/any -p is.xyz.mpv -d "https://example.org/media.png" </pre>
+		<pre>am start -a android.intent.action.VIEW -d "https://example.com/abc" --es "tls-verify" "no"  --es "title" "finally"
+--es "user-agent" "Mozilla/5.0 (Linux; Android 10; potato) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36"
+--es "http-header-fields" "Accept-Language: en-RO\\,en;q=0.9\\,ro-RO;q=0.8\\,ro;q=0.7\\,en-US;q=0.6,Accept: */*" </pre>
 		</div>
+		<h4>Notice that commas inside a header field's value are double escaped </h4>
 	</details>
 
 	<h2 id="result-intent">Result Intent</h2>

--- a/docs/intent.html
+++ b/docs/intent.html
@@ -51,40 +51,40 @@
 	</p>
 	<ul>
 		<li>
-			<code>sub-file</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-file">manual</a>] add one subtitle file to the list of external subtitles. This subtitle file is displayed by default <br>
+			<code>--sub-file</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-file">manual</a>] add one subtitle file to the list of external subtitles. This subtitle file is displayed by default <br>
 			*Due to how android intents work, using this option multiple times will just overwrite its value
 		</li>
 		<li>
-			<code>sub-files</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-files">manual</a>] add multiple subtitle files separated by <code>:</code> <br>
+			<code>--sub-files</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-files">manual</a>] add multiple subtitle files separated by <code>:</code> <br>
 			*Playback will not start until all subtitle files are fetched, adding a lot of subtitle URLs may cause a significant delay
 		</li>
 		<li>
-			<code>http-header-fields</code> (String): [<a href="https://mpv.io/manual/master/#options-http-header-fields">manual</a>] set custom HTTP fields when accessing HTTP stream. Fields are separated by commas <br>
+			<code>--http-header-fields</code> (String): [<a href="https://mpv.io/manual/master/#options-http-header-fields">manual</a>] set custom HTTP fields when accessing HTTP stream. Fields are separated by commas <br>
 			*Escape commas inside a field's value with a backslash
 		</li>
 		<li>
-			<code>user-agent</code> (String): [<a href="https://mpv.io/manual/master/#options-user-agent">manual</a>] specify user agent for HTTP streaming
+			<code>--user-agent</code> (String): [<a href="https://mpv.io/manual/master/#options-user-agent">manual</a>] specify user agent for HTTP streaming
 		</li>
 		<li>
-			<code>referrer</code> (String): [<a href="https://mpv.io/manual/master/#options-referrer">manual</a>] specify a referrer path or URL for HTTP requests
+			<code>--referrer</code> (String): [<a href="https://mpv.io/manual/master/#options-referrer">manual</a>] specify a referrer path or URL for HTTP requests
 		</li>
 		<li>
-			<code>media-title</code>,<code>force-media-title</code> (String): [<a href="https://mpv.io/manual/master/#options-force-media-title">manual</a>] set a custom title <br>
+			<code>--media-title</code>,<code>force-media-title</code> (String): [<a href="https://mpv.io/manual/master/#options-force-media-title">manual</a>] set a custom title <br>
 			*Because it's common among android players, you can also use <code>title</code>
 		</li>
 		<li>
-			<code>tls-verify</code> (String): [<a href="https://mpv.io/manual/master/#options-tls-verify">manual</a>] verify peer certificates when using TLS
+			<code>--tls-verify</code> (String): [<a href="https://mpv.io/manual/master/#options-tls-verify">manual</a>] verify peer certificates when using TLS
 		</li>
 		
 		<li>
-			<code>resume-playback</code> (String): [<a href="https://mpv.io/manual/master/#options-no-resume-playback">manual</a>] specify if playback time should be resotred. 
+			<code>--resume-playback</code> (String): [<a href="https://mpv.io/manual/master/#options-no-resume-playback">manual</a>] specify if playback time should be resotred. 
 		</li>
 		<li>
-			<code>force-seekable</code> (String): [<a href="https://mpv.io/manual/master/#options-force-seekable">manual</a>] 
+			<code>--force-seekable</code> (String): [<a href="https://mpv.io/manual/master/#options-force-seekable">manual</a>] 
 			If the player thinks that the media is not seekable (e.g. playing from a pipe,or it's an http stream with a server that doesn't support range requests), seeking will be disabled. This option can forcibly enable it. For seeks within the cache, there's a good chance of success.
 		</li>
 		<li>
-			<code>cookies</code> (String): [<a href="https://mpv.io/manual/master/#options-cookies">manual</a>] support cookies when making HTTP requests. Disabled by default.
+			<code>--cookies</code> (String): [<a href="https://mpv.io/manual/master/#options-cookies">manual</a>] support cookies when making HTTP requests. Disabled by default.
 		</li>
 	</ul>
 
@@ -104,18 +104,18 @@ startActivity(intent)</pre>
 		<pre>// you must urlencode ";" (to "%3b") when it's not used to separate elements in the intent uri syntax
 // you need 2 backslashes or one urlencoded backslash to escape characters inside a field's value
 var a = document.createElement("a"),
-    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.sub-file=https://test/en.vtt;S.sub-files=https\\://test/ita.vtt:https\\://test/fra.vtt;S.referrer=https://test;S.tls-verify=no;S.title=my title;S.user-agent=Mozilla/5.0 (Linux%3b Android 10%3b device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36;S.http-header-fields=Accept-Language: en-GB\\,en%3bq=0.5;end"
+    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.--sub-file=https://test/en.vtt;S.--sub-files=https\\://test/ita.vtt:https\\://test/fra.vtt;S.--referrer=https://test;S.--tls-verify=no;S.title=my title;S.--user-agent=Mozilla/5.0 (Linux%3b Android 10%3b device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36;S.--http-header-fields=Accept-Language: en-GB\\,en%3bq=0.5;end"
 a.href = string
 a.click()</pre>
 		<pre>// you can also urlencode all the values
 var a = document.createElement("a"),
-    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.sub-file=https%3A%2F%2Ftest%2Fen.vtt;S.sub-files=https%5C%3A%2F%2Ftest%2Fita.vtt%3Ahttps%5C%3A%2F%2Ftest%2Ffra.vtt;S.referrer=https%3A%2F%2Ftest;S.tls-verify=no;S.title=my%20title;S.user-agent=Mozilla%2F5.0%20(Linux%3B%20Android%2010%3B%20device)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F107.0.0.0%20Mobile%20Safari%2F537.36;S.http-header-fields=Accept-Language%3A%20en-GB%5C%2Cen%3Bq%3D0.5;end"
+    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.--sub-file=https%3A%2F%2Ftest%2Fen.vtt;S.--sub-files=https%5C%3A%2F%2Ftest%2Fita.vtt%3Ahttps%5C%3A%2F%2Ftest%2Ffra.vtt;S.--referrer=https%3A%2F%2Ftest;S.--tls-verify=no;S.title=my%20title;S.--user-agent=Mozilla%2F5.0%20(Linux%3B%20Android%2010%3B%20device)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F107.0.0.0%20Mobile%20Safari%2F537.36;S.--http-header-fields=Accept-Language%3A%20en-GB%5C%2Cen%3Bq%3D0.5;end"
 a.href = string
 a.click()</pre>
 			<p>you can play around with intent URIs in android using <a href="https://github.com/kiwibrowser/src.next">Kiwi Browser</a>'s dev tools</p>
 		<h5>Command line (e.g. adb or Termux)</h5>
 		<pre>am start -a android.intent.action.VIEW -t video/any -p is.xyz.mpv -d "https://example.org/media.png" </pre>
-		<pre>am start -a android.intent.action.VIEW -t video/any -d https://example/vid.mp4 --es title "my title" --es sub-file "https://test/en.vtt" --es sub-files "https\://test/ita.vtt:https\://test/fra.vtt" --es http-header-fields "Accept-Language: en-GB\,en;q=0.5" --es user-agent "Mozilla/5.0 (Linux; Android 10; device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36" --es referrer "https://test" --es tls-verify no
+		<pre>am start -a android.intent.action.VIEW -t video/any -d https://example/vid.mp4 --es title "my title" --es --sub-file "https://test/en.vtt" --es --sub-files "https\://test/ita.vtt:https\://test/fra.vtt" --es --http-header-fields "Accept-Language: en-GB\,en;q=0.5" --es --user-agent "Mozilla/5.0 (Linux; Android 10; device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36" --es --referrer "https://test" --es --tls-verify no
 		</pre>
 		</div>
 	</details>

--- a/docs/intent.html
+++ b/docs/intent.html
@@ -29,6 +29,7 @@
 	<p>If you need to force an URL to be opened in mpv even though file extension 
 	may not match set the MIME type to <code>video/any</code>.<br>
 	extras: <i>(optional)</i></p>
+	<p style="margin-left: 1rem;">MX Player-like options:</p>
 	<ul>
 		<li>
 			<code>decode_mode</code> (Byte): if set to 2, hardware decoding will be disabled
@@ -40,47 +41,59 @@
 			<code>subs.enable</code> (ParcelableArray of Uri): specifies which of the subtitles should be selected by default, subset of previous array
 		</li>
 		<li>
-			<code>sub-file</code> (String): add one subtitle file to the list of external subtitles. This subtitle file is displayed by default
-		</li>
-		<li>
-			<code>sub-files</code> (String): add multiple subtitle files separated by ;
-		</li>
-		<li>
 			<code>position</code> (Int): starting point of video playback in milliseconds
 		</li>
+	</ul>
+
+	<p style="margin-left: 1rem;">
+		mpv options: <br>
+		*no-flag option syntax is not supported. Use, for example, resume-playback=no instead of no-resume-playback
+	</p>
+	<ul>
 		<li>
-			<code>user-agent</code> (String): specify user agent for HTTP streaming
+			<code>sub-file</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-file">manual</a>] add one subtitle file to the list of external subtitles. This subtitle file is displayed by default <br>
+			*Due to how android intents work, using this option multiple times will just overwrite its value
 		</li>
 		<li>
-			<code>referrer</code> (String): specify a referrer path or URL for HTTP requests
+			<code>sub-files</code> (String): [<a href="https://mpv.io/manual/master/#options-sub-files">manual</a>] add multiple subtitle files separated by <code>:</code> <br>
+			*Playback will not start until all subtitle files are fetched, adding a lot of subtitle URLs may cause a significant delay
 		</li>
 		<li>
-			<code>http-header-fields</code> (String): set custom HTTP fields when accessing HTTP stream. Fields are separated by commas <br>
-			Escape commas inside a field's value with a backslash 
-			<pre>Accept: */*,Accept-Language: en-RO\,en;q=0.9\,ro-RO;q=0.8\,ro;q=0.7\,en-US;q=0.6 </pre>
+			<code>http-header-fields</code> (String): [<a href="https://mpv.io/manual/master/#options-http-header-fields">manual</a>] set custom HTTP fields when accessing HTTP stream. Fields are separated by commas <br>
+			*Escape commas inside a field's value with a backslash
 		</li>
 		<li>
-			<code>tls-verify</code> (String): verify peer certificates when using TLS 
+			<code>user-agent</code> (String): [<a href="https://mpv.io/manual/master/#options-user-agent">manual</a>] specify user agent for HTTP streaming
 		</li>
 		<li>
-			<code>title</code> (String): specify title to be used instead of filename
+			<code>referrer</code> (String): [<a href="https://mpv.io/manual/master/#options-referrer">manual</a>] specify a referrer path or URL for HTTP requests
 		</li>
 		<li>
-			<code>resume-playback</code> (String): specify if playback time should be resotred with "yes" or "no"
+			<code>media-title</code>,<code>force-media-title</code> (String): [<a href="https://mpv.io/manual/master/#options-force-media-title">manual</a>] set a custom title <br>
+			*Because it's common among android players, you can also use <code>title</code>
 		</li>
 		<li>
-			<code>force-seekable</code> (String): If the player thinks that the media is not seekable (e.g. playing from a pipe,
-	or it's an http stream with a server that doesn't support range requests), seeking will be disabled.
-	This option can forcibly enable it. For seeks within the cache, there's a good chance of success.
+			<code>tls-verify</code> (String): [<a href="https://mpv.io/manual/master/#options-tls-verify">manual</a>] verify peer certificates when using TLS
+		</li>
+		
+		<li>
+			<code>resume-playback</code> (String): [<a href="https://mpv.io/manual/master/#options-no-resume-playback">manual</a>] specify if playback time should be resotred. 
 		</li>
 		<li>
-			<code>cookies</code> (String): support cookies when making HTTP requests. Disabled by default.
+			<code>force-seekable</code> (String): [<a href="https://mpv.io/manual/master/#options-force-seekable">manual</a>] 
+			If the player thinks that the media is not seekable (e.g. playing from a pipe,or it's an http stream with a server that doesn't support range requests), seeking will be disabled. This option can forcibly enable it. For seeks within the cache, there's a good chance of success.
+		</li>
+		<li>
+			<code>cookies</code> (String): [<a href="https://mpv.io/manual/master/#options-cookies">manual</a>] support cookies when making HTTP requests. Disabled by default.
 		</li>
 	</ul>
 
 	<details>
 		<summary>Examples</summary>
 		<div style="margin-left: 1em;">
+		<p>
+			<a href="https://github.com/k3b/intent-intercept">Intent Intercept</a> and <a href="https://github.com/MuntashirAkon/AppManager">AppManager</a>'s <a href="https://muntashirakon.github.io/AppManager/en/#sec:interceptor-page">interceptor</a> option are useful for debugging on android
+		</p>
 		<h5>Kotlin</h5>
 		<pre>val intent = Intent(Intent.ACTION_VIEW)
 intent.setDataAndType(Uri.parse("https://example.org/media.png"), "video/any")
@@ -88,16 +101,23 @@ intent.setPackage("is.xyz.mpv")
 startActivity(intent)</pre>
 		<h5>HTML (Chrome)</h5>
 		<pre>&lt;a href="intent://example.org/media.png#Intent;type=video/any;package=is.xyz.mpv;scheme=https;end;"&gt;Click me&lt;/a&gt;</pre>
-		<pre>&lt;a href="intent:https://example.com/abc#Intent;package=is.xyz.mpv;S.title=abc;S.http-header-fields=Cookie: key1=val1%3b 
-key2=val2,Accept: */*,Accept-Language: en-RO%5c,en%3bq=0.9%5c,ro-RO%3bq=0.8%5c,ro%3bq=0.7%5c,en-US%3bq=0.6;end;"&gt;Click me&lt;/a&gt;</pre>
-		<h4>Notice that semicolons, backslashes must be urlencoded (; => %3b and \ => %5c)</h4>
+		<pre>// you must urlencode ";" (to "%3b") when it's not used to separate elements in the intent uri syntax
+// you need 2 backslashes or one urlencoded backslash to escape characters inside a field's value
+var a = document.createElement("a"),
+    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.sub-file=https://test/en.vtt;S.sub-files=https\\://test/ita.vtt:https\\://test/fra.vtt;S.referrer=https://test;S.tls-verify=no;S.title=my title;S.user-agent=Mozilla/5.0 (Linux%3b Android 10%3b device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36;S.http-header-fields=Accept-Language: en-GB\\,en%3bq=0.5;end"
+a.href = string
+a.click()</pre>
+		<pre>// you can also urlencode all the values
+var a = document.createElement("a"),
+    string = "intent://example/vid.mp4#Intent;scheme=https;type=video/any;S.sub-file=https%3A%2F%2Ftest%2Fen.vtt;S.sub-files=https%5C%3A%2F%2Ftest%2Fita.vtt%3Ahttps%5C%3A%2F%2Ftest%2Ffra.vtt;S.referrer=https%3A%2F%2Ftest;S.tls-verify=no;S.title=my%20title;S.user-agent=Mozilla%2F5.0%20(Linux%3B%20Android%2010%3B%20device)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F107.0.0.0%20Mobile%20Safari%2F537.36;S.http-header-fields=Accept-Language%3A%20en-GB%5C%2Cen%3Bq%3D0.5;end"
+a.href = string
+a.click()</pre>
+			<p>you can play around with intent URIs in android using <a href="https://github.com/kiwibrowser/src.next">Kiwi Browser</a>'s dev tools</p>
 		<h5>Command line (e.g. adb or Termux)</h5>
 		<pre>am start -a android.intent.action.VIEW -t video/any -p is.xyz.mpv -d "https://example.org/media.png" </pre>
-		<pre>am start -a android.intent.action.VIEW -d "https://example.com/abc" --es "tls-verify" "no"  --es "title" "finally"
---es "user-agent" "Mozilla/5.0 (Linux; Android 10; potato) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36"
---es "http-header-fields" "Accept-Language: en-RO\\,en;q=0.9\\,ro-RO;q=0.8\\,ro;q=0.7\\,en-US;q=0.6,Accept: */*" </pre>
+		<pre>am start -a android.intent.action.VIEW -t video/any -d https://example/vid.mp4 --es title "my title" --es sub-file "https://test/en.vtt" --es sub-files "https\://test/ita.vtt:https\://test/fra.vtt" --es http-header-fields "Accept-Language: en-GB\,en;q=0.5" --es user-agent "Mozilla/5.0 (Linux; Android 10; device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Mobile Safari/537.36" --es referrer "https://test" --es tls-verify no
+		</pre>
 		</div>
-		<h4>Notice that commas inside a header field's value are double escaped </h4>
 	</details>
 
 	<h2 id="result-intent">Result Intent</h2>


### PR DESCRIPTION
support for setting: user-agent, referrer, http-header-fields, tls-verify and title from intent extras
partially fixes https://github.com/mpv-android/mpv-android/issues/427, i did not add all the options requested there