### PR TITLE
Switch `mpv` build to `meson`

### DIFF
--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -15,21 +15,18 @@ fi
 
 unset CC CXX # meson wants these unset
 
-build_opts=(
-	'--default-library' 'shared'
-	'-Diconv=disabled'
-	'-Dlua=enabled'
-	'-Dlibmpv=true'
-	'-Dcplayer=false'
-	'-Dmanpage-build=disabled'
-)
-
+action='setup'
 if [ -d $build ]; then
-	build_opts+=('--reconfigure')
+	action='configure'
 fi
 
-meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
-	"${build_opts[@]}"
+meson $action $build --cross-file "$prefix_dir"/crossfile.txt \
+	--default-library shared \
+	-Diconv=disabled \
+	-Dlua=enabled \
+	-Dlibmpv=true \
+	-Dcplayer=false \
+	-Dmanpage-build=disabled
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -15,12 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-action='setup'
-if [ -d $build ]; then
-	action='configure'
-fi
-
-meson $action $build --cross-file "$prefix_dir"/crossfile.txt \
+meson $build --cross-file "$prefix_dir"/crossfile.txt \
 	--default-library shared \
 	-Diconv=disabled \
 	-Dlua=enabled \

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -4,10 +4,12 @@
 
 build=_build$ndk_suffix
 
+# Meson must clean the build directory or it will build a static library instead of a shared one
+rm -rf $build
+
 if [ "$1" == "build" ]; then
 	true
 elif [ "$1" == "clean" ]; then
-	rm -rf $build
 	exit 0
 else
 	exit 255
@@ -16,12 +18,7 @@ fi
 unset CC CXX # meson wants these unset
 
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	--default-library=shared \
-	--buildtype=plain \
-	-Diconv=disabled \
-	-Dlua=enabled \
-	-Dlibmpv=true \
-	-Dmanpage-build=disabled
+	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -19,7 +19,7 @@ fi
 unset CC CXX # meson wants these unset
 
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	--default-library=shared \
+	--default-library shared \
 	-Diconv=disabled \
 	-Dlua=enabled \
 	-Dlibmpv=true \

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -2,23 +2,26 @@
 
 . ../../include/path.sh
 
+build=_build$ndk_suffix
+
 if [ "$1" == "build" ]; then
 	true
 elif [ "$1" == "clean" ]; then
-	rm -rf _build$ndk_suffix
+	rm -rf $build
 	exit 0
 else
 	exit 255
 fi
 
-[ -f waf ] || ./bootstrap.py
+unset CC CXX # meson wants these unset
 
-PKG_CONFIG="pkg-config --static" \
-./waf configure \
-	--disable-iconv --lua=52 \
-	--enable-libmpv-shared \
-	--disable-manpage-build \
-	-o "`pwd`/_build$ndk_suffix"
+meson $build --cross-file "$prefix_dir"/crossfile.txt \
+	--default-library=shared \
+	--buildtype=plain \
+	-Diconv=disabled \
+	-Dlua=enabled \
+	-Dlibmpv=true \
+	-Dmanpage-build=disabled
 
-./waf build -j$cores
-./waf install --destdir="$prefix_dir"
+ninja -C $build -j$cores
+DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -4,13 +4,10 @@
 
 build=_build$ndk_suffix
 
-
-# Meson must clean the build directory or it will build a static library instead of a shared one
-rm -rf $build
-
 if [ "$1" == "build" ]; then
 	true
 elif [ "$1" == "clean" ]; then
+	rm -rf $build
 	exit 0
 else
 	exit 255
@@ -18,12 +15,20 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	--default-library shared \
-	-Diconv=disabled \
-	-Dlua=enabled \
-	-Dlibmpv=true \
-	-Dmanpage-build=disabled
+build_opts=(
+	'--default-library' 'shared'
+	'-Diconv=disabled'
+	'-Dlua=enabled'
+	'-Dlibmpv=true'
+	'-Dmanpage-build=disabled'
+)
+
+if [ -d $build ]; then
+	build_opts+=('--reconfigure')
+fi
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	"${build_opts[@]}"
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -18,7 +18,6 @@ fi
 
 unset CC CXX # meson wants these unset
 
-PKG_CONFIG="pkg-config --static" \
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
 	--default-library=shared \
 	--buildtype=plain \
@@ -27,5 +26,5 @@ meson $build --cross-file "$prefix_dir"/crossfile.txt \
 	-Dlibmpv=true \
 	-Dmanpage-build=disabled
 
-ninja -C $build -j$coreshttps://github.com/mpv-android/mpv-android/pull/58
+ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -4,6 +4,7 @@
 
 build=_build$ndk_suffix
 
+
 # Meson must clean the build directory or it will build a static library instead of a shared one
 rm -rf $build
 
@@ -17,8 +18,14 @@ fi
 
 unset CC CXX # meson wants these unset
 
+PKG_CONFIG="pkg-config --static" \
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
+	--default-library=shared \
+	--buildtype=plain \
+	-Diconv=disabled \
+	-Dlua=enabled \
+	-Dlibmpv=true \
+	-Dmanpage-build=disabled
 
-ninja -C $build -j$cores
+ninja -C $build -j$coreshttps://github.com/mpv-android/mpv-android/pull/58
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -20,7 +20,6 @@ unset CC CXX # meson wants these unset
 
 meson $build --cross-file "$prefix_dir"/crossfile.txt \
 	--default-library=shared \
-	--buildtype=plain \
 	-Diconv=disabled \
 	-Dlua=enabled \
 	-Dlibmpv=true \

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -20,6 +20,7 @@ build_opts=(
 	'-Diconv=disabled'
 	'-Dlua=enabled'
 	'-Dlibmpv=true'
+	'-Dcplayer=false'
 	'-Dmanpage-build=disabled'
 )
 


### PR DESCRIPTION
This seems to be more consistent with the rest of the build scripts, and I found that the build is faster than `waf`. I've tested building with `meson` and it works on my Samsung Galaxy S20 in both `arm64` and `armv7l` modes