### PR TITLE
Make incremental meson builds faster

### DIFF
--- a/buildscripts/scripts/dav1d.sh
+++ b/buildscripts/scripts/dav1d.sh
@@ -15,8 +15,19 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
+build_opts=(
+	'-Denable_tests=false'
+	'-Db_lto=true'
+	'-Dstack_alignment=16'
+)
+
+if [ -d $build ]; then
+	build_opts+=("--reconfigure")
+fi
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	"${build_opts[@]}"
+	  
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/freetype2.sh
+++ b/buildscripts/scripts/freetype2.sh
@@ -15,7 +15,14 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt
+build_opts=()
+
+if [ -d $build ]; then
+	build_opts+=("--reconfigure")
+fi
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	"${build_opts[@]}"
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/fribidi.sh
+++ b/buildscripts/scripts/fribidi.sh
@@ -15,8 +15,14 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	-D{tests,docs}=false
+build_opts=('-Dtests=false' '-Ddocs=false')
+
+if [ -d $build ]; then
+	build_opts+=("--reconfigure")
+fi
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	"${build_opts[@]}"	
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/harfbuzz.sh
+++ b/buildscripts/scripts/harfbuzz.sh
@@ -15,8 +15,14 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
-	-Dtests=disabled
+build_opts=('-Dtests=disabled')
+
+if [ -d $build ]; then
+	build_opts+=("--reconfigure")
+fi
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	"${build_opts[@]}"
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install


### PR DESCRIPTION
By checking if the build directory already exists, and telling `meson` to `--reconfigure` if it does, it makes multiple successive builds much faster.