### PR TITLE
AndroidManifest: add category for launchers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         android:icon="@mipmap/mpv_launcher_icon"
         android:roundIcon="@mipmap/mpv_launcher_icon"
         android:banner="@mipmap/ic_banner"
-        android:label="@string/mpv_activity">
+        android:label="@string/mpv_activity"
+        android:appCategory="video">
 
         <!-- Multi-window support on some devices -->
         <meta-data android:name="com.samsung.android.sdk.multiwindow.enable"


### PR DESCRIPTION
makes mpv-android show up as a video app on launchers that automatically sort apps, common on android TV