### PR TITLE
buildscripts: fix meson deprecation warning about missing setup command

### DIFF
--- a/buildscripts/scripts/dav1d.sh
+++ b/buildscripts/scripts/dav1d.sh
@@ -15,7 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
 	-Denable_tests=false -Db_lto=true -Dstack_alignment=16
 
 ninja -C $build -j$cores

--- a/buildscripts/scripts/freetype2.sh
+++ b/buildscripts/scripts/freetype2.sh
@@ -15,7 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/fribidi.sh
+++ b/buildscripts/scripts/fribidi.sh
@@ -15,7 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
 	-D{tests,docs}=false
 
 ninja -C $build -j$cores

--- a/buildscripts/scripts/harfbuzz.sh
+++ b/buildscripts/scripts/harfbuzz.sh
@@ -15,7 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
 	-Dtests=disabled -Ddocs=disabled
 
 ninja -C $build -j$cores

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -15,7 +15,7 @@ fi
 
 unset CC CXX # meson wants these unset
 
-meson $build --cross-file "$prefix_dir"/crossfile.txt \
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
 	--default-library shared \
 	-Diconv=disabled -Dlua=enabled \
 	-Dlibmpv=true -Dcplayer=false \


### PR DESCRIPTION
fixed warning:
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.