### PR TITLE
enable ipfs protocols (ipfs and ipns)

### DIFF
--- a/app/src/main/java/is/xyz/mpv/Utils.kt
+++ b/app/src/main/java/is/xyz/mpv/Utils.kt
@@ -412,6 +412,6 @@ object Utils {
     // cf. AndroidManifest.xml and MPVActivity.resolveUri()
     val PROTOCOLS = setOf(
         "file", "content", "http", "https",
-        "rtmp", "rtmps", "rtp", "rtsp", "mms", "mmst", "mmsh", "tcp", "udp", "lavf"
+        "rtmp", "rtmps", "rtp", "rtsp", "mms", "mmst", "mmsh", "tcp", "udp", "lavf", "ipfs", "ipns"
     )
 }


### PR DESCRIPTION
Allows to type a URL like:
ipfs://<cid>
ipns://<cid>

mpv already allows this, just mpv-android didn't.

I'm intentionally keeping this commit clean and simple even though this commit on it's own isn't that useful. A user still can't actually do `ipfs://<cid>` because a gateway is needed for that. I'll make a separate PR for that. It's all already possible by modifying mpv.conf though (that pr is just going to make it more easier to set).