### PR TITLE
allow to set IPFS gateway in config

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -121,6 +121,10 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
         val screenshotDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
         screenshotDir.mkdirs()
         MPVLib.setOptionString("screenshot-directory", screenshotDir.path)
+
+        // Set IPFS gateway
+        val ipfsGateway = sharedPreferences.getString("ipfs_gateway", "")
+        MPVLib.setOptionString("stream-lavf-o", "gateway=$ipfsGateway")
     }
 
     fun playFile(filePath: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,10 @@
     <string name="pref_default_subtitle_language_message">Select subtitle language(s) to be selected by default when playing a video with multiple subtitles. Multiple values can be delimited by comma.\nTwo- or three-letter languages codes typically work. Multiple values can be delimited by comma.</string>
     <string name="pref_default_subtitle_language_summary" translatable="false">%s</string>
 
+    <string name="pref_ipfs_gateway_title">IPFS Gateway</string>
+    <string name="pref_ipfs_gateway_message">Set the gateway to handle ipfs:// and ipns:// URLs</string>
+    <string name="pref_ipfs_gateway_summary" translatable="false">%s</string>
+
     <string name="pref_hardware_decoding_title">Hardware decoding</string>
     <string name="pref_hardware_decoding_summary">Attempt hardware decoding before falling back to software</string>
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -21,6 +21,13 @@
         android:dialogMessage="@string/pref_default_subtitle_language_message"
         android:title="@string/pref_default_subtitle_language_title" />
 
+    <is.xyz.mpv.config.SummaryEditTextPreference
+        android:defaultValue=""
+        android:key="ipfs_gateway"
+        android:summary="@string/pref_default_subtitle_language_summary"
+        android:dialogMessage="@string/pref_ipfs_gateway_message"
+        android:title="@string/pref_ipfs_gateway_title" />
+
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="hardware_decoding"


### PR DESCRIPTION
This allows setting the IPFS gateway as one of the setting general. Making it far easier - low barier - to actually play with IPFS.

It can also still be set/changed in mpv.conf for the advanced users.

This along with https://github.com/mpv-android/mpv-android/pull/743 allows IPFS to be used in a fairly simple manner.

Edit: Just tried this on the commandline.
These work just fine there:
```
mpv lavf://ipfs://bafybeigagd5nmnn2iys2f3doro7ydrevyr2mzarwidgadawmamiteydbzi --stream-lavf-o-set=gateway=http://10.0.4.2:8080
mpv lavf://ipfs://bafybeigagd5nmnn2iys2f3doro7ydrevyr2mzarwidgadawmamiteydbzi --stream-lavf-o=gateway=http://10.0.4.2:8080
```

Yet the `stream-lavf-o-set` through `MPVLib.setOptionString` doesn't appear to be working.
Is that intentional or a bug? Or am i doing something wrong?

I want to use the `-set` suffix version as at a later moment i'm going to change values in there on the fly. That probably won't be a PR here as it's very specific to a pet project of mine.