### PR TITLE
Do not always force building armv7l

### DIFF
--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -1,5 +1,8 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+PREFIX = $(PREFIX32)
+endif
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 PREFIX = $(PREFIX64)
 endif

--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -1,4 +1,7 @@
-APP_ABI := armeabi-v7a
+APP_ABI :=
+ifneq ($(PREFIX32),)
+APP_ABI += armeabi-v7a
+endif
 ifneq ($(PREFIX64),)
 APP_ABI += arm64-v8a
 endif

--- a/buildscripts/scripts/mpv-android.sh
+++ b/buildscripts/scripts/mpv-android.sh
@@ -26,11 +26,17 @@ nativeprefix () {
 	fi
 }
 
+prefix32=$(nativeprefix "armv7l")
 prefix64=$(nativeprefix "arm64")
 prefix_x64=$(nativeprefix "x86_64")
 prefix_x86=$(nativeprefix "x86")
 
-PREFIX=$BUILD/prefix/armv7l PREFIX64=$prefix64 PREFIX_X64=$prefix_x64 PREFIX_X86=$prefix_x86 \
+if [[ -z "$prefix32" && -z "$prefix64" && -z "$prefix_x64" && -z "$prefix_x86" ]]; then
+	echo >&2 "Error: no mpv library detected."
+	exit 255
+fi
+
+PREFIX32=$prefix32 PREFIX64=$prefix64 PREFIX_X64=$prefix_x64 PREFIX_X86=$prefix_x86 \
 ndk-build -C app/src/main -j$cores
 
 targets=(assembleDebug assembleRelease)


### PR DESCRIPTION
This allows building arm64 apk with a single command ./buildall.sh --arch arm64
The APP_ABI should only be selected by setting --arch in command line.