### PR TITLE
Add force hardware plus detection setting

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -42,14 +42,18 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
         MPVLib.setOptionString("profile", "fast")
 
         // vo
-        val vo = if (sharedPreferences.getBoolean("gpu_next", false))
+        val vo = if (sharedPreferences.getBoolean("hardware_plus_decoding", false))
+            "mediacodec_embed"
+        else if (sharedPreferences.getBoolean("gpu_next", false))
             "gpu-next"
         else
             "gpu"
         voInUse = vo
 
         // hwdec
-        val hwdec = if (sharedPreferences.getBoolean("hardware_decoding", true))
+        val hwdec = if (sharedPreferences.getBoolean("hardware_plus_decoding", false))
+            "mediacodec"
+        else if (sharedPreferences.getBoolean("hardware_decoding", true))
             "auto"
         else
             "no"
@@ -353,7 +357,7 @@ internal class MPVView(context: Context, attrs: AttributeSet) : SurfaceView(cont
     fun cyclePause() = MPVLib.command(arrayOf("cycle", "pause"))
     fun cycleAudio() = MPVLib.command(arrayOf("cycle", "audio"))
     fun cycleSub() = MPVLib.command(arrayOf("cycle", "sub"))
-    fun cycleHwdec() = MPVLib.command(arrayOf("cycle-values", "hwdec", "auto", "no"))
+    fun cycleHwdec() = MPVLib.command(arrayOf("cycle-values", "hwdec", "mediacodec", "auto", "no"))
 
     fun cycleSpeed() {
         val speeds = arrayOf(0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,9 @@
     <string name="pref_hardware_decoding_title">Hardware decoding</string>
     <string name="pref_hardware_decoding_summary">Attempt hardware decoding before falling back to software</string>
 
+    <string name="pref_hardware_plus_decoding_title">Force hardware plus detection</string>
+    <string name="pref_hardware_plus_decoding_summary">Attempt hardware plus decoding before falling back to software</string>
+
     <string name="pref_background_play_title">Background playback</string>
     <string name="pref_background_play_summary">Select when playback should be automatically resumed background</string>
     <string name="pref_background_play_default" translatable="false">never</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -27,6 +27,12 @@
         android:summary="@string/pref_hardware_decoding_summary"
         android:title="@string/pref_hardware_decoding_title" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="hardware_plus_decoding"
+        android:summary="@string/pref_hardware_plus_decoding_summary"
+        android:title="@string/pref_hardware_plus_decoding_title" />
+
     <ListPreference
         android:defaultValue="@string/pref_background_play_default"
         android:key="background_play"


### PR DESCRIPTION
Mpv is unable to automatically detect hardware plus decoding on my device without manually editing mpv's config.  This PR adds a checkbox underneath the current Hardware Decoding setting to forcibly enable hardware plus decoding. `hwdec` is set to "mediacodec" and `vo` is set to "mediacodec_embed".