### PR TITLE
MPVActivity: prevent screen timeout

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -1699,7 +1699,9 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
 
     private fun eventUi(eventId: Int) {
         if (!activityIsForeground) return
-        // empty
+        when (eventId) {
+            MPVLib.mpvEventId.MPV_EVENT_PLAYBACK_RESTART -> updatePlaybackStatus(player.paused!!)
+        }
     }
 
     override fun eventProperty(property: String) {


### PR DESCRIPTION
On MPV_EVENT_PLAYBACK_RESTART, it is necessary in certain cases to call updatePlaybackStatus so that FLAG_KEEP_SCREEN_ON is added, otherwise this windowmanager flag may never get set and the screen times out during playback.

This reverts commit 6902b73fb5be86e4306bda2dabc58d89451f1bd3.