### PR TITLE
Update mbedtls to 3.6.1 LTS

### DIFF
--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -14,7 +14,7 @@ v_unibreak=6.1
 v_harfbuzz=9.0.0
 v_fribidi=1.0.15
 v_freetype=2-13-2
-v_mbedtls=3.5.2
+v_mbedtls=v3.6.1
 
 
 ## Dependency tree

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -9,9 +9,13 @@ mkdir -p deps && cd deps
 
 # mbedtls
 if [ ! -d mbedtls ]; then
-	mkdir mbedtls
-	$WGET https://github.com/ARMmbed/mbedtls/archive/mbedtls-$v_mbedtls.tar.gz -O - | \
-		tar -xz -C mbedtls --strip-components=1
+	git clone --recurse-submodules https://github.com/Mbed-TLS/mbedtls -b $v_mbedtls
+else
+	cd mbedtls
+	git fetch
+	git checkout $v_mbedtls
+	git submodule update --init --recursive --rebase
+	cd ..
 fi
 
 # dav1d

--- a/buildscripts/scripts/mbedtls.sh
+++ b/buildscripts/scripts/mbedtls.sh
@@ -2,21 +2,19 @@
 
 . ../../include/path.sh
 
+build=_build$ndk_suffix
+
 if [ "$1" == "build" ]; then
 	true
 elif [ "$1" == "clean" ]; then
-	make clean
+	rm -rf $build
 	exit 0
 else
 	exit 255
 fi
 
-$0 clean # separate building not supported, always clean
-if [[ "$ndk_triple" == "i686"* ]]; then
-	./scripts/config.py unset MBEDTLS_AESNI_C
-else
-	./scripts/config.py set MBEDTLS_AESNI_C
-fi
+cmake -B $build -G "Ninja" \
+	-DENABLE_TESTING=OFF -DENABLE_PROGRAMS=OFF
 
-make -j$cores no_test
-make DESTDIR="$prefix_dir" install
+ninja -C $build -j$cores
+DESTDIR="$prefix_dir" ninja -C $build install


### PR DESCRIPTION
Fixes CVE-2024-28960, CVE-2024-28755, CVE-2024-28836

mbedtls has been changed to use a git repo because it's framework submodule is also now required and it is not included in the packaged source file.