### PR TITLE
install meson in virtual environment

### DIFF
--- a/buildscripts/include/download-sdk.sh
+++ b/buildscripts/include/download-sdk.sh
@@ -11,15 +11,17 @@ if [ "$os" == "linux" ]; then
 	if [ $TRAVIS -eq 0 ]; then
 		if hash yum &>/dev/null; then
 			sudo yum install autoconf pkgconfig libtool ninja-build \
-			python3-pip unzip wget
-			pip3 install -U meson
+				python3-pip unzip wget python3-venv
 		elif apt-get -v &>/dev/null; then
 			sudo apt-get install autoconf pkg-config libtool ninja-build \
-			python3-pip unzip wget
-			pip3 install -U meson
+				python3-pip unzip wget python3-venv
 		else
 			echo "Note: dependencies were not installed, you have to do that manually."
 		fi
+
+		[ -d "$DIR/sdk/venv" ] || python3 -m venv "$DIR/sdk/venv"
+		. "$DIR/sdk/venv/bin/activate"
+		pip3 install -U meson
 	fi
 
 	if ! javac -version &>/dev/null; then

--- a/buildscripts/include/path.sh
+++ b/buildscripts/include/path.sh
@@ -30,3 +30,7 @@ toolchain=$(echo "$DIR/sdk/android-ndk-${v_ndk}/toolchains/llvm/prebuilt/"*)
 	export PATH="$toolchain/bin:$DIR/sdk/android-ndk-${v_ndk}:$DIR/sdk/bin:$PATH"
 export ANDROID_HOME="$DIR/sdk/android-sdk-$os"
 unset ANDROID_SDK_ROOT ANDROID_NDK_ROOT
+
+if [ -z "$VIRTUAL_ENV" -a -e "$DIR/sdk/venv/bin/activate" ]; then
+	. "$DIR/sdk/venv/bin/activate"
+fi


### PR DESCRIPTION
On recent Debian and Ubuntu versions running `pip3 install -U meson` fails with the following message:
```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

This patch creates a python virtual environment using the venv package and installs meson there. The environment then gets activated in `buildscripts/include/path.sh` if present.

A simpler solution would be to just install the meson package from the debian repository. The version packaged with the current stable debian bookworm works and building with debian oldstable fails anyways due to the java runtime being too old.