### PR TITLE
install meson from debian repository

### DIFF
--- a/buildscripts/include/download-sdk.sh
+++ b/buildscripts/include/download-sdk.sh
@@ -15,8 +15,7 @@ if [ "$os" == "linux" ]; then
 			pip3 install -U meson
 		elif apt-get -v &>/dev/null; then
 			sudo apt-get install autoconf pkg-config libtool ninja-build \
-			python3-pip unzip wget
-			pip3 install -U meson
+				python3-pip unzip wget meson
 		else
 			echo "Note: dependencies were not installed, you have to do that manually."
 		fi

--- a/buildscripts/include/download-sdk.sh
+++ b/buildscripts/include/download-sdk.sh
@@ -15,7 +15,7 @@ if [ "$os" == "linux" ]; then
 			pip3 install -U meson
 		elif apt-get -v &>/dev/null; then
 			sudo apt-get install autoconf pkg-config libtool ninja-build \
-				python3-pip unzip wget meson
+				unzip wget meson
 		else
 			echo "Note: dependencies were not installed, you have to do that manually."
 		fi


### PR DESCRIPTION
Because Debian no longer allows installing packages system-wide using pip.