### PR TITLE
Small fixes for English, Ukrainian and Russian translations

### DIFF
--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -6,7 +6,7 @@
         <item>16:10</item>
         <item>4:3</item>
         <item>2.35:1</item>
-        <item>Panscan</item> <!-- TODO -->
+        <item>Panscan</item>
     </string-array>
     <string-array name="background_play_entries">
         <item>Никогда</item>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -6,7 +6,7 @@
         <item>16:10</item>
         <item>4:3</item>
         <item>2.35:1</item>
-        <item>Pan/Scan</item> <!-- TODO -->
+        <item>Panscan</item> <!-- TODO -->
     </string-array>
     <string-array name="background_play_entries">
         <item>Никогда</item>

--- a/app/src/main/res/values-uk/arrays.xml
+++ b/app/src/main/res/values-uk/arrays.xml
@@ -7,7 +7,7 @@
         <item>16:10</item>
         <item>4:3</item>
         <item>2.35:1</item>
-        <item>Панорамування/Cканування</item>
+        <item>Panscan</item>
     </string-array>
 
     <!-- Arrays used in settings -->

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -7,7 +7,7 @@
         <item>16:10</item>
         <item>4:3</item>
         <item>2.35:1</item>
-        <item>Pan/Scan</item>
+        <item>Panscan</item>
     </string-array>
     <string-array name="aspect_ratios" translatable="false">
         <!-- = `video-aspect-override` in mpv -->


### PR DESCRIPTION
"Panscan" is the name of the "Pan and Scan" function. And it's called exactly "Panscan". You can confirm it by turning it on or off. Therefore, it's best not to invent or rename it.

![202409071755](https://github.com/user-attachments/assets/e6827cf6-8561-4703-bfe8-2dad4427132f)


As for the Ukrainian or Russian translation, these are the languages I'm proficient in. It's quite pointless to translate this function directly, as it's similar to translating the word Wi-Fi. In summary — it isn't worth translating.