### PR TITLE
KeyMapping: add mapping for colour keys

### DIFF
--- a/app/src/main/java/is/xyz/mpv/KeyMapping.java
+++ b/app/src/main/java/is/xyz/mpv/KeyMapping.java
@@ -77,5 +77,11 @@ class KeyMapping {
         map.put(KEYCODE_NUMPAD_9, "KP9");
         map.put(KEYCODE_NUMPAD_DOT, "KP_DEC");
         map.put(KEYCODE_NUMPAD_ENTER, "KP_ENTER");
+
+        // Special mapping of programmable colour keys
+        map.put(KEYCODE_PROG_RED, "F13");
+        map.put(KEYCODE_PROG_GREEN, "F14");
+        map.put(KEYCODE_PROG_YELLOW, "F15");
+        map.put(KEYCODE_PROG_BLUE, "F16");
     }
 }


### PR DESCRIPTION
The keys are mapped to the function keys which are analogous to the coloured programmable function keys in a TV remote.

Side-note: Is there a good place to document this for the end user? Perhaps we can add an input test mode in the app to let the user find out the key mappings via experimentation.