### PR TITLE
Add support for right-to-left languages

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:resizeableActivity="true"
         android:requestLegacyExternalStorage="true"
         android:preserveLegacyExternalStorage="true"
+        android:supportsRtl="true"
         android:icon="@mipmap/mpv_launcher_icon"
         android:roundIcon="@mipmap/mpv_launcher_icon"
         android:banner="@mipmap/ic_banner"

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -77,6 +77,7 @@
                 android:id="@+id/controls_seekbar_group"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layoutDirection="ltr"
                 android:orientation="horizontal"
                 android:weightSum="100">
 
@@ -133,6 +134,7 @@
                 android:id="@+id/controls_button_group"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layoutDirection="ltr"
                 android:gravity="center"
                 android:orientation="horizontal">
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -23,7 +23,9 @@
     <string name="btn_pause">مکث</string>
     <string name="ui_volume">صدا: %d٪</string>
     <string name="ui_brightness">روشنایی: %d٪</string>
-    <string name="ui_seek_distance">%1$s\n[%2$s]</string>
+    
+    <!-- The following string contains the Unicode LRM character(U+200E) to represent the + or - character before the time. -->
+    <string name="ui_seek_distance">%1$s\n[‎%2$s]</string>
     <string name="ui_fps">%.3f فریم‌برثانیه</string>
     <string name="ui_speed">%.2fx</string>
     <string name="ui_chapter_fallback">فصل %1$d (%2$s)</string>


### PR DESCRIPTION
Hello.
In this request, I enabled the right-to-left language support feature so that when the program starts with languages such as Persian, the settings and text are aligned on the right.
When this feature is enabled, when displaying a video, the progress bar moves from right to left, which does not match the hand gestures, and the control buttons are also aligned on the right, which also causes the previous and next track buttons to be displayed incorrectly when playing a music list.