### PR TITLE
AndroidManifest: signal support for SEND and SEND_MULTIPLE intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -180,6 +180,19 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <!-- Receive shared media files -->
+            <intent-filter android:label="@string/label_share_intent">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/label_share_intent">
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
@@ -87,7 +87,9 @@ abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(
         MPVLib.setOptionString("force-window", "yes")
 
         if (filePath != null) {
-            MPVLib.command(arrayOf("loadfile", filePath as String))
+            val path = filePath!!
+            val method = if (path.startsWith("memory://")) "loadlist" else "loadfile"
+            MPVLib.command(arrayOf(method, path, "replace"))
             filePath = null
         } else {
             // We disable video output when the context disappears, enable it back

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,7 +39,7 @@
     <!-- Less simple strings -->
     <string name="title_speed_dialog">Playback speed</string>
     <string name="error_no_file">No file given, exiting</string>
-    <string name="notice_file_appended">File was appended to playlist</string>
+    <string name="notice_file_appended">File(s) appended to playlist</string>
     <string name="exit_warning_playlist">%d playlist items remaining.\nDo you really want to exit?</string>
     <string name="contrast">Contrast</string>
     <string name="video_brightness">Video brightness</string>


### PR DESCRIPTION
AndroidManifest: signal support for SEND and SEND_MULTIPLE intent for audio and video files and implement handling

this intent adds support for example to share videos from the gallery and select mpv-android as the destination