### PR TITLE
MPVActivity: don't switch to the audio ui when a video file/stream is loading

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -384,6 +384,10 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
     private fun isPlayingAudioOnly(): Boolean {
         if (!isPlayingAudio)
             return false
+        val aid = MPVLib.getPropertyInt("aid")
+        val vid = MPVLib.getPropertyInt("vid")
+        if((aid ?: 0) == 0 && (vid ?: 0) == 0)
+            return false
         val image = MPVLib.getPropertyString("current-tracks/video/image")
         return image.isNullOrEmpty() || image == "yes"
     }


### PR DESCRIPTION
MPVActivity: don't switch to the audio ui when a video file/stream is loading