### PR TITLE
Fix spelling issues flagged by codespell

### DIFF
--- a/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
@@ -43,7 +43,7 @@ abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(
      * Call this once before the view is destroyed.
      */
     fun destroy() {
-        // Disable surface callbacks to avoid using unintialized mpv state
+        // Disable surface callbacks to avoid using uninitialized mpv state
         holder.removeCallback(this)
 
         MPVLib.destroy()

--- a/app/src/main/java/is/xyz/mpv/DecimalPickerDialog.kt
+++ b/app/src/main/java/is/xyz/mpv/DecimalPickerDialog.kt
@@ -14,7 +14,7 @@ internal class DecimalPickerDialog(
     override fun buildView(layoutInflater: LayoutInflater): View {
         binding = DialogDecimalBinding.inflate(layoutInflater)
 
-        // hide extranous UI parts
+        // hide extraneous UI parts
         arrayOf(binding.label1, binding.label2, binding.rowSecondary).forEach {
             it.visibility = View.GONE
         }

--- a/app/src/main/java/is/xyz/mpv/FilePickerActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/FilePickerActivity.kt
@@ -52,7 +52,7 @@ class FilePickerActivity : AppCompatActivity(), AbstractFilePickerFragment.OnFil
         }
 
         // The basic issue we have here is this: https://stackoverflow.com/questions/31190612/
-        // Some part of the view hierachy swallows the insets during fragment transitions
+        // Some part of the view hierarchy swallows the insets during fragment transitions
         // and it's impossible to invoke this calculation a second time (requestApplyInsets doesn't help).
         // For that reason I wrote this creative workaround, it works surprisingly well.
         findViewById<View>(R.id.fragment_container_view).setOnApplyWindowInsetsListener { _, insets ->

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -543,7 +543,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
                 )
             becomingNoisyReceiverRegistered = true
             // (re-)request audio focus
-            // Note that this will actually request focus everytime the user unpauses, refer to discussion in #1066
+            // Note that this will actually request focus every time the user unpauses, refer to discussion in #1066
             if (requestAudioFocus()) {
                 onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN, "request")
             } else {
@@ -810,7 +810,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
     }
 
     private fun interceptDpad(ev: KeyEvent): Boolean {
-        if (btnSelected == -1) { // UP and DOWN are always grabbed and overriden
+        if (btnSelected == -1) { // UP and DOWN are always grabbed and overridden
             when (ev.keyCode) {
                 KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN -> {
                     if (ev.action == KeyEvent.ACTION_DOWN) { // activate dpad navigation
@@ -824,7 +824,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             return false
         }
 
-        // this runs when dpad nagivation is active:
+        // this runs when dpad navigation is active:
         when (ev.keyCode) {
             KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN -> {
                 if (ev.action == KeyEvent.ACTION_DOWN) { // deactivate dpad navigation
@@ -879,14 +879,14 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
     private fun interceptKeyDown(event: KeyEvent): Boolean {
         // intercept some keys to provide functionality "native" to
         // mpv-android even if libmpv already implements these
-        var unhandeled = 0
+        var unhandled = 0
 
         when (event.unicodeChar.toChar()) {
             // (overrides a default binding)
             'j' -> cycleSub()
             '#' -> cycleAudio()
 
-            else -> unhandeled++
+            else -> unhandled++
         }
         // Note: dpad center is bound according to how Android TV apps should generally behave,
         // see <https://developer.android.com/docs/quality-guidelines/tv-app-quality>.
@@ -904,10 +904,10 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             // (overrides a default binding)
             KeyEvent.KEYCODE_ENTER -> player.cyclePause()
 
-            else -> unhandeled++
+            else -> unhandled++
         }
 
-        return unhandeled < 2
+        return unhandled < 2
     }
 
     private fun onBackPressedImpl() {

--- a/app/src/main/java/is/xyz/mpv/Utils.kt
+++ b/app/src/main/java/is/xyz/mpv/Utils.kt
@@ -181,7 +181,7 @@ internal object Utils {
             m[c.id] = c
         }
         group.removeAllViews()
-        // Readd children in specified order and unhide
+        // Re-add children in specified order and unhide
         for (id in idOrder) {
             val c = m.remove(id) ?: error("$group did not have child with id=$id")
             c.visibility = View.VISIBLE

--- a/buildscripts/scripts/lua.sh
+++ b/buildscripts/scripts/lua.sh
@@ -11,7 +11,7 @@ else
 	exit 255
 fi
 
-# Building seperately from source tree is not supported, this means we are forced to always clean
+# Building separately from source tree is not supported, this means we are forced to always clean
 $0 clean
 
 mycflags=(


### PR DESCRIPTION
- correct comment typos in lua build script and Kotlin sources (separately, extraneous, uninitialized, hierarchy) @buildscripts/scripts/lua.sh#14-14 @app/src/main/java/is/xyz/mpv/DecimalPickerDialog.kt#17-20 @app/src/main/java/is/xyz/mpv/BaseMPVView.kt#45-48 @app/src/main/java/is/xyz/mpv/FilePickerActivity.kt#54-57
- normalize wording in MPVActivity comments and logic (every time, overridden, navigation, unhandled) @app/src/main/java/is/xyz/mpv/MPVActivity.kt#536-910
- spell “Re-add” correctly in Utils view reordering helper @app/src/main/java/is/xyz/mpv/Utils.kt#184-189

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-11-30T14:17:06Z
Repository: mpv-android
Branch: master
Signing: GPG (989AF9F0)
Performance: 6 files, +12/-12 lines