### PR TITLE
Build libass with fontconfig support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install autoconf pkg-config libtool ninja-build python3-pip
+          sudo apt-get install autoconf pkg-config libtool ninja-build python3-pip gperf
           sudo pip3 install meson
 
       - name: Download deps

--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -15,6 +15,8 @@ v_harfbuzz=12.3.2
 v_fribidi=1.0.16
 v_freetype=2.14.1
 v_mbedtls=3.6.5
+v_libxml2=2.15.2
+v_fontconfig=2.17.1
 
 
 ## Dependency tree
@@ -27,7 +29,9 @@ dep_freetype2=()
 dep_fribidi=()
 dep_harfbuzz=()
 dep_unibreak=()
-dep_libass=(freetype2 fribidi harfbuzz unibreak)
+dep_libxml2=()
+dep_fontconfig=(libxml2)
+dep_libass=(freetype2 fribidi harfbuzz unibreak fontconfig)
 dep_lua=()
 dep_libplacebo=()
 dep_mpv=(ffmpeg libass lua libplacebo)
@@ -40,4 +44,4 @@ dep_mpv_android=(mpv)
 v_ci_ffmpeg=n8.0
 
 # filename used to uniquely identify a build prefix
-ci_tarball="prefix-ndk-${v_ndk}-lua-${v_lua}-unibreak-${v_unibreak}-harfbuzz-${v_harfbuzz}-fribidi-${v_fribidi}-freetype-${v_freetype}-mbedtls-${v_mbedtls}-ffmpeg-${v_ci_ffmpeg}.tgz"
+ci_tarball="prefix-ndk-${v_ndk}-lua-${v_lua}-unibreak-${v_unibreak}-harfbuzz-${v_harfbuzz}-fribidi-${v_fribidi}-freetype-${v_freetype}-libxml2-${v_libxml2}-fontconfig-${v_fontconfig}-mbedtls-${v_mbedtls}-ffmpeg-${v_ci_ffmpeg}.tgz"

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -47,6 +47,20 @@ if [ ! -d unibreak ]; then
 		tar -xz -C unibreak --strip-components=1
 fi
 
+# libxml2
+if [ ! -d libxml2 ]; then
+	mkdir libxml2
+	$WGET https://gitlab.gnome.org/GNOME/libxml2/-/archive/v${v_libxml2}/libxml2-v${v_libxml2}.tar.gz -O - | \
+		tar -xz -C libxml2 --strip-components=1
+fi
+
+# fontconfig
+if [ ! -d fontconfig ]; then
+	mkdir fontconfig
+	$WGET https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/${v_fontconfig}/fontconfig-${v_fontconfig}.tar.gz -O - | \
+		tar -xz -C fontconfig --strip-components=1
+fi
+
 # libass
 [ ! -d libass ] && git clone https://github.com/libass/libass
 

--- a/buildscripts/include/download-sdk.sh
+++ b/buildscripts/include/download-sdk.sh
@@ -11,10 +11,10 @@ if [ "$os" == "linux" ]; then
 	if [ $IN_CI -eq 0 ]; then
 		if hash yum &>/dev/null; then
 			sudo yum install autoconf pkgconfig libtool ninja-build \
-				unzip wget meson
+				unzip wget meson gperf
 		elif apt-get -v &>/dev/null; then
 			sudo apt-get install autoconf pkg-config libtool ninja-build \
-				unzip wget meson
+				unzip wget meson gperf
 		else
 			echo "Note: dependencies were not installed, you have to do that manually."
 		fi
@@ -38,7 +38,7 @@ elif [ "$os" == "mac" ]; then
 		fi
 		brew install \
 			automake autoconf libtool pkg-config \
-			coreutils gnu-sed wget meson ninja
+			coreutils gnu-sed wget meson ninja gperf
 	fi
 	if ! javac -version &>/dev/null; then
 		echo "Error: missing Java Development Kit. Install it manually."

--- a/buildscripts/scripts/fontconfig.sh
+++ b/buildscripts/scripts/fontconfig.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+. ../../include/path.sh
+
+build=_build$ndk_suffix
+
+if [ "$1" == "build" ]; then
+	true
+elif [ "$1" == "clean" ]; then
+	rm -rf $build
+	exit 0
+else
+	exit 255
+fi
+
+unset CC CXX # meson wants these unset
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	-Dtests=disabled \
+	-Ddoc=disabled \
+	-Dtools=disabled \
+	-Dxml-backend=libxml2
+
+ninja -C $build -j$cores
+DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/libass.sh
+++ b/buildscripts/scripts/libass.sh
@@ -19,7 +19,7 @@ cd _build$ndk_suffix
 ../configure \
 	--host=$ndk_triple --with-pic \
 	--enable-static --disable-shared \
-	--enable-libunibreak --disable-require-system-font-provider
+	--enable-libunibreak --enable-fontconfig
 
 make -j$cores
 make DESTDIR="$prefix_dir" install

--- a/buildscripts/scripts/libxml2.sh
+++ b/buildscripts/scripts/libxml2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+. ../../include/path.sh
+
+build=_build$ndk_suffix
+
+if [ "$1" == "build" ]; then
+	true
+elif [ "$1" == "clean" ]; then
+	rm -rf $build
+	exit 0
+else
+	exit 255
+fi
+
+unset CC CXX # meson wants these unset
+
+meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
+	-Diconv=disabled
+
+ninja -C $build -j$cores
+DESTDIR="$prefix_dir" ninja -C $build install

--- a/docs/print_releasenotes.sh
+++ b/docs/print_releasenotes.sh
@@ -15,6 +15,8 @@ lines=(
 	"* mbedtls $v_mbedtls"
 	"* dav1d videolan/dav1d@$(commit_hash dav1d)"
 	"* ffmpeg ffmpeg/ffmpeg@$(commit_hash ffmpeg)"
+	"* libxml2 $v_libxml2"
+	"* fontconfig $v_fontconfig"
 	"* freetype ${v_freetype//-/.}"
 	"* fribidi $v_fribidi"
 	"* harfbuzz $v_harfbuzz"


### PR DESCRIPTION
libass will use fontconfig to find fonts installed into the system. Without this, libass couldn't find system fonts, so it was always using the "subfont.ttf" setted by mpv by default.

Fix:
- https://github.com/mpv-android/mpv-android/issues/1169
- https://github.com/mpv-android/mpv-android/issues/1072