### PR TITLE
BackgroundPlaybackService: fix notification thumbnail on pre-Oreo dev…

### DIFF
--- a/app/src/main/java/is/xyz/mpv/BackgroundPlaybackService.kt
+++ b/app/src/main/java/is/xyz/mpv/BackgroundPlaybackService.kt
@@ -76,7 +76,7 @@ class BackgroundPlaybackService : Service(), MPVLib.EventObserver {
 
         // With an active media session, the media style will override everything
         // (including the thumbnail) and we can skip doing this.
-        if (mediaToken != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (mediaToken == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             thumbnail?.let {
                 builder.setLargeIcon(it)
 


### PR DESCRIPTION
…ices

Commit 5eb28a427eecd9f7f954a5242b958dc623e152a2
("BackgroundPlaybackService: skip unnecessary notification customization attempts") restricted the manual thumbnail setup to *only* execute on newer devices with a media token, completely bypassing it on older devices where
manual setup is strictly required.

Fixes: 5eb28a427eecd9f7f954a5242b958dc623e152a2