### PR TITLE
MPVActivity: fix volume gesture and audio focus when lavfi-complex is used

### DIFF
--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -402,10 +402,15 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
     }
 
     private fun updateAudioPresence() {
-        val haveAudio = MPVLib.getPropertyBoolean("current-tracks/audio/selected")
-        if (haveAudio == null) {
-            // If we *don't know* if there's an active audio track then don't update to avoid
-            // spurious UI changes. The property will become available again later.
+        val selected = MPVLib.getPropertyBoolean("current-tracks/audio/selected")
+        // With --lavfi-complex audio can play without any track being selected, so
+        // additionally check if the audio output chain is configured.
+        val haveAudio = selected == true ||
+                !MPVLib.getPropertyString("audio-params/format").isNullOrEmpty()
+        if (selected == null && !haveAudio) {
+            // If we *don't know* if there's an active audio track (and no audio chain is
+            // configured either) then don't update to avoid spurious UI changes.
+            // The properties will become available again later.
             return
         }
         isPlayingAudio = (haveAudio && MPVLib.getPropertyBoolean("mute") != true)
@@ -1889,7 +1894,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         if (!activityIsForeground) return
         when (property) {
             "track-list" -> player.loadTracks()
-            "current-tracks/audio/selected", "current-tracks/video/image" -> updateAudioUI()
+            "current-tracks/audio/selected", "current-tracks/video/image", "audio-params/format" -> updateAudioUI()
             "hwdec-current" -> updateDecoderButton()
         }
         if (metaUpdated)
@@ -1949,11 +1954,11 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
                 1 -> PlaybackStateCompat.REPEAT_MODE_ALL
                 else -> PlaybackStateCompat.REPEAT_MODE_NONE
             })
-        } else if (property == "current-tracks/audio/selected") {
+        } else if (property == "current-tracks/audio/selected" || property == "audio-params/format") {
             updateAudioPresence()
         }
 
-        if (property == "pause" || property == "current-tracks/audio/selected")
+        if (property == "pause" || property == "current-tracks/audio/selected" || property == "audio-params/format")
             handleAudioFocus()
 
         if (!activityIsForeground) return

--- a/app/src/main/java/is/xyz/mpv/MPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVView.kt
@@ -195,7 +195,8 @@ internal class MPVView(context: Context, attrs: AttributeSet) : BaseMPVView(cont
             Property("shuffle", MPV_FORMAT_FLAG),
             Property("hwdec-current"),
             Property("mute", MPV_FORMAT_FLAG),
-            Property("current-tracks/audio/selected")
+            Property("current-tracks/audio/selected"),
+            Property("audio-params/format")
         )
 
         for ((name, format) in p)


### PR DESCRIPTION
With `--lavfi-complex` audio can play without any track being selected, in which case `current-tracks/audio/selected` never indicates audio presence, so `isPlayingAudio` stays false: the volume gesture is disabled (`maxVolume = 0`) and audio focus is never requested. This additionally checks `audio-params/format`, which is available iff the audio output chain is configured, and observes it so the state updates on audio reconfig (the property maps to `MPV_EVENT_AUDIO_RECONFIG`, which also fires on chain teardown, so no stale state).

The playlist-gap early-return from 770aa49 (#1135) is preserved: in a gap both properties are unavailable and the function still returns without updating.

Reproduced and verified on a Pixel 3 (Android 15): with `lavfi-complex=sine=frequency=440[ao]` in mpv.conf the volume gesture does nothing on current master (a simple `[aid1]...[ao]` graph is already covered by mpv's selected-track fallback in `current-tracks`); with this change the gesture and audio focus work. Normal files behave identically before/after.

fixes #1143