### PR TITLE
buildscripts: use non-blocking entropy pool for mbedtls

### DIFF
--- a/buildscripts/scripts/mbedtls.sh
+++ b/buildscripts/scripts/mbedtls.sh
@@ -18,5 +18,8 @@ else
 	./scripts/config.py set MBEDTLS_AESNI_C
 fi
 
+# since 3.6.6 mbedTLS defaults to /dev/random, which is known to block unnecessarily
+./scripts/config.py set MBEDTLS_PLATFORM_DEV_RANDOM '"/dev/urandom"'
+
 make -j$cores no_test
 make DESTDIR="$prefix_dir" install


### PR DESCRIPTION
closes: https://github.com/mpv-android/mpv-android/issues/1297