### PR TITLE
Add renovate

### DIFF
--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -10,14 +10,14 @@ v_sdk_platform=36
 v_sdk_build_tools=36.0.0
 
 v_lua=5.2.4
-v_unibreak=7.0
+v_unibreak=7_0
 v_harfbuzz=14.3.1
 v_fribidi=1.0.16
-v_freetype=2.14.3
+v_freetype=2-14-3
 v_mbedtls=3.6.7
 v_libxml2=2.15.3
 v_fontconfig=2.18.2
-v_curl=8.21.0
+v_curl=8_21_0
 
 
 ## Dependency tree
@@ -42,7 +42,7 @@ dep_mpv_android=(mpv)
 ## for CI workflow
 
 # pinned ffmpeg revision
-v_ci_ffmpeg=n9.0
+v_ci_ffmpeg=9.0
 
 # filename used to uniquely identify a build prefix
 ci_tarball="prefix-n${v_ndk}-l${v_lua}-u${v_unibreak}-h${v_harfbuzz}-fr${v_fribidi}-ft${v_freetype}-x${v_libxml2}-fo${v_fontconfig}-m${v_mbedtls}-c${v_curl}-ff${v_ci_ffmpeg}.tgz"

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -20,12 +20,12 @@ fi
 # ffmpeg
 if [ ! -d ffmpeg ]; then
 	args=()
-	[ $IN_CI -eq 1 ] && args+=(--depth=1 -b "$v_ci_ffmpeg")
+	[ $IN_CI -eq 1 ] && args+=(--depth=1 -b "n$v_ci_ffmpeg")
 	git clone https://github.com/FFmpeg/FFmpeg ffmpeg "${args[@]}"
 fi
 
 # freetype2
-[ ! -d freetype2 ] && git clone --recurse-submodules https://gitlab.freedesktop.org/freetype/freetype.git freetype2 -b VER-${v_freetype//./-}
+[ ! -d freetype2 ] && git clone --recurse-submodules https://gitlab.freedesktop.org/freetype/freetype.git freetype2 -b VER-$v_freetype
 
 # fribidi
 if [ ! -d fribidi ]; then
@@ -44,7 +44,7 @@ fi
 # unibreak
 if [ ! -d unibreak ]; then
 	mkdir unibreak
-	$WGET https://github.com/adah1972/libunibreak/releases/download/libunibreak_${v_unibreak//./_}/libunibreak-${v_unibreak}.tar.gz -O - | \
+	$WGET https://github.com/adah1972/libunibreak/releases/download/libunibreak_${v_unibreak}/libunibreak-${v_unibreak//_/.}.tar.gz -O - | \
 		tar -xz -C unibreak --strip-components=1
 fi
 
@@ -78,7 +78,7 @@ fi
 # curl
 if [ ! -d curl ]; then
 	mkdir curl
-	$WGET https://curl.se/download/curl-$v_curl.tar.gz -O - | \
+	$WGET https://github.com/curl/curl/releases/download/curl-$v_curl/curl-${v_curl//_/.}.tar.gz -O - | \
 		tar -xz -C curl --strip-components=1
 fi
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [    
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_unibreak=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "adah1972/libunibreak",
+      "extractVersionTemplate": "^libunibreak_(?<version>.*)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)_(?<minor>\\d+)(?:-(?<patch>\\d+))?$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_harfbuzz=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "harfbuzz/harfbuzz"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_fribidi=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "fribidi/fribidi",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_freetype=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org",
+      "packageNameTemplate": "freetype/freetype",
+      "extractVersionTemplate": "^VER-(?<version>.*)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)-(?<minor>\\d+)(?:-(?<patch>\\d+))?$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_libxml2=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.gnome.org",
+      "packageNameTemplate": "GNOME/libxml2",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_fontconfig=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "gitlab-tags",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org",
+      "packageNameTemplate": "fontconfig/fontconfig"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_curl=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "curl/curl",
+      "extractVersionTemplate": "^curl-(?<version>.*)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^buildscripts/include/depinfo\\.sh$/"],
+      "matchStrings": ["v_ci_ffmpeg=(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "FFmpeg/FFmpeg",
+      "extractVersionTemplate": "^n(?<version>.*)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?<prerelease>[^.-]+)?$"
+    }
+  ]
+}


### PR DESCRIPTION
This PR add renovate with a [customManagers](https://docs.renovatebot.com/modules/manager/regex/) for all the C/C++ dependencies.
The goal of renovate is to automatically update dependencies.

I tested it on my fork by downgrading all the dependencies and by verifying that renovate was creating the PR like this should. See: https://github.com/moi15moi/mpv-android

If you merge this PR, note that you will need to configure/install renovate. See https://github.com/apps/renovate to learn how to properly configure it.

PS: I did not add mbedTLS because from what I can see, you will remove it soon (https://github.com/mpv-android/mpv-android/pull/1312). I also didn't add lua since I believe you want it to be freezed at 5.2.4.