### PR TITLE
Enable asm with libass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install autoconf pkgconf libtool ninja-build python3-pip gperf
+          sudo apt-get install autoconf pkgconf libtool ninja-build python3-pip gperf nasm
           sudo pip3 install meson
 
       - name: Download or build deps

--- a/buildscripts/include/download-sdk.sh
+++ b/buildscripts/include/download-sdk.sh
@@ -11,10 +11,10 @@ if [ "$os" == "linux" ]; then
 	if [ $IN_CI -eq 0 ]; then
 		if hash yum &>/dev/null; then
 			sudo yum install autoconf pkgconfig libtool ninja-build \
-				unzip wget meson gperf
+				unzip wget meson gperf nasm
 		elif apt-get -v &>/dev/null; then
 			sudo apt-get install autoconf pkg-config libtool ninja-build \
-				unzip wget meson gperf
+				unzip wget meson gperf nasm
 		else
 			echo "Note: dependencies were not installed, you have to do that manually."
 		fi
@@ -38,7 +38,7 @@ elif [ "$os" == "mac" ]; then
 		fi
 		brew install \
 			automake autoconf libtool pkg-config \
-			coreutils gnu-sed wget meson ninja gperf
+			coreutils gnu-sed wget meson ninja gperf nasm
 	fi
 	if ! javac -version &>/dev/null; then
 		echo "Error: missing Java Development Kit. Install it manually."

--- a/buildscripts/scripts/libass.sh
+++ b/buildscripts/scripts/libass.sh
@@ -13,13 +13,19 @@ fi
 
 [ -f configure ] || ./autogen.sh
 
+asm_args=
+if [ "$ndk_triple" != "arm-linux-androideabi" ]; then
+	asm_args=--enable-asm
+fi
+
 mkdir -p _build$ndk_suffix
 cd _build$ndk_suffix
 
 ../configure \
 	--host=$ndk_triple --with-pic \
 	--enable-static --disable-shared \
-	--enable-libunibreak --enable-fontconfig
+	--enable-libunibreak --enable-fontconfig \
+	$asm_args
 
 make -j$cores
 make DESTDIR="$prefix_dir" install


### PR DESCRIPTION
This boost performance a lot.
Note that libass doesn't support arm32 bits asm, so we won't enable it for that platform.