### PR TITLE
external display support [closes #728]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/is/xyz/mpv/BackgroundPlaybackService.kt
+++ b/app/src/main/java/is/xyz/mpv/BackgroundPlaybackService.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.os.Handler
 import android.os.IBinder
+import android.os.PowerManager
 import android.support.v4.media.session.MediaSessionCompat
 import android.util.Log
 import androidx.annotation.DrawableRes
@@ -32,6 +33,26 @@ class BackgroundPlaybackService : Service(), MPVLib.EventObserver {
         thumbnailHandler = Handler(mainLooper)
 
         MPVLib.addObserver(this)
+        instance = this
+    }
+
+    // Held only while playback is continuing on an external display: that's a heavier, more
+    // sustained workload than plain audio-only backgrounding, which today gets away without one
+    // (likely riding on the foreground-service-media-playback Doze exemption).
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    private fun updateWakeLock(active: Boolean) {
+        if (active) {
+            if (wakeLock?.isHeld != true) {
+                val pm = getSystemService(POWER_SERVICE) as PowerManager
+                wakeLock = pm.newWakeLock(
+                    PowerManager.PARTIAL_WAKE_LOCK, "mpv-android:external-display"
+                ).apply { acquire() }
+            }
+        } else {
+            wakeLock?.let { if (it.isHeld) it.release() }
+            wakeLock = null
+        }
     }
 
     private lateinit var thumbnailHandler: Handler
@@ -128,6 +149,7 @@ class BackgroundPlaybackService : Service(), MPVLib.EventObserver {
         paused = MPVLib.getPropertyBoolean("pause") == true
         shouldShowPrevNext = (MPVLib.getPropertyInt("playlist-count") ?: 0) > 1
         thumbnailHandler.postDelayed(thumbnailRunnable, THUMB_DELAY)
+        updateWakeLock(intent.getBooleanExtra(EXTRA_EXTERNAL_DISPLAY_ACTIVE, false))
 
         // create notification and turn this into a "foreground service"
 
@@ -146,6 +168,8 @@ class BackgroundPlaybackService : Service(), MPVLib.EventObserver {
         MPVLib.removeObserver(this)
 
         thumbnailHandler.removeCallbacksAndMessages(null)
+        updateWakeLock(false)
+        instance = null
 
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(NOTIFICATION_ID)
@@ -197,6 +221,20 @@ class BackgroundPlaybackService : Service(), MPVLib.EventObserver {
         var mediaToken: MediaSessionCompat.Token? = null
         /* Set by MPVActivity; to notify on thumbnail changes */
         var thumbnailChanged: (() -> Unit)? = null
+
+        /* Intent extra: whether this (re)start is (also) motivated by an active external display */
+        const val EXTRA_EXTERNAL_DISPLAY_ACTIVE = "external_display_active"
+
+        private var instance: BackgroundPlaybackService? = null
+
+        /**
+         * Called by MPVActivity whenever ExternalDisplayManager's active state changes, so the
+         * wake lock can be dropped promptly if we're already running for some other reason
+         * (e.g. audio-only backgrounding) once projection ends.
+         */
+        fun setExternalDisplayActive(active: Boolean) {
+            instance?.updateWakeLock(active)
+        }
 
         private const val NOTIFICATION_ID = 12345
         private const val NOTIFICATION_CHANNEL_ID = "background_playback"

--- a/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
+++ b/app/src/main/java/is/xyz/mpv/BaseMPVView.kt
@@ -2,19 +2,21 @@ package `is`.xyz.mpv
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
-import android.view.SurfaceHolder
 import android.view.SurfaceView
 
 // Contains only the essential code needed to get a picture on the screen
 
-abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(context, attrs), SurfaceHolder.Callback {
+abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(context, attrs) {
+    private val surfaceCallback = MPVSurfaceCallback.forPhone()
+
     /**
      * Initialize libmpv.
      *
      * Call this once before the view is shown.
      */
     fun initialize(configDir: String, cacheDir: String) {
+        MPVSurfaceCoordinator.reset()
+
         MPVLib.create(context.applicationContext)
 
         /* set normal options (user-supplied config can override) */
@@ -33,7 +35,7 @@ abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(
         // need to idle at least once for playFile() logic to work
         MPVLib.setOptionString("idle", "once")
 
-        holder.addCallback(this)
+        holder.addCallback(surfaceCallback)
         observeProperties()
     }
 
@@ -44,7 +46,7 @@ abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(
      */
     fun destroy() {
         // Disable surface callbacks to avoid using uninitialized mpv state
-        holder.removeCallback(this)
+        holder.removeCallback(surfaceCallback)
 
         MPVLib.destroy()
     }
@@ -54,59 +56,18 @@ abstract class BaseMPVView(context: Context, attrs: AttributeSet) : SurfaceView(
 
     protected abstract fun observeProperties()
 
-    private var filePath: String? = null
-
     /**
      * Set the first file to be played once the player is ready.
      */
     fun playFile(filePath: String) {
-        this.filePath = filePath
+        MPVSurfaceCoordinator.setPendingFilePath(filePath)
     }
-
-    private var voInUse: String = "gpu"
 
     /**
      * Sets the VO to use.
      * It is automatically disabled/enabled when the surface dis-/appears.
      */
     fun setVo(vo: String) {
-        voInUse = vo
-        MPVLib.setOptionString("vo", vo)
-    }
-
-    // Surface callbacks
-
-    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-        MPVLib.setPropertyString("android-surface-size", "${width}x$height")
-    }
-
-    override fun surfaceCreated(holder: SurfaceHolder) {
-        Log.w(TAG, "attaching surface")
-        MPVLib.attachSurface(holder.surface)
-        // This forces mpv to render subs/osd/whatever into our surface even if it would ordinarily not
-        MPVLib.setOptionString("force-window", "yes")
-
-        if (filePath != null) {
-            MPVLib.command(arrayOf("loadfile", filePath as String))
-            filePath = null
-        } else {
-            // We disable video output when the context disappears, enable it back
-            MPVLib.setPropertyString("vo", voInUse)
-        }
-    }
-
-    override fun surfaceDestroyed(holder: SurfaceHolder) {
-        Log.w(TAG, "detaching surface")
-        MPVLib.setPropertyString("vo", "null")
-        MPVLib.setPropertyString("force-window", "no")
-        // Note that before calling detachSurface() we need to be sure that libmpv
-        // is done using the surface.
-        // FIXME: There could be a race condition here, because I don't think
-        // setting a property will wait for VO deinit.
-        MPVLib.detachSurface()
-    }
-
-    companion object {
-        private const val TAG = "mpv"
+        MPVSurfaceCoordinator.setVo(vo)
     }
 }

--- a/app/src/main/java/is/xyz/mpv/ExternalDisplayManager.kt
+++ b/app/src/main/java/is/xyz/mpv/ExternalDisplayManager.kt
@@ -1,0 +1,83 @@
+package `is`.xyz.mpv
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * Watches for a connected external (secondary) display eligible for [android.app.Presentation]
+ * (HDMI, USB-C DisplayPort-alt-mode, or an OS-managed wireless display) and shows/dismisses an
+ * [ExternalDisplayPresentation] on it accordingly.
+ */
+class ExternalDisplayManager(
+    private val context: Context,
+    private val onStateChanged: (active: Boolean) -> Unit,
+) {
+    private val displayManager =
+        context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+    private val handler = Handler(Looper.getMainLooper())
+
+    private var presentation: ExternalDisplayPresentation? = null
+
+    /** Settings-driven enable/disable flag; set from MPVActivity.readSettings(). */
+    var enabled: Boolean = true
+        set(value) {
+            field = value
+            reconcile()
+        }
+
+    val isActive: Boolean
+        get() = presentation != null
+
+    private val listener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = reconcile()
+        override fun onDisplayRemoved(displayId: Int) = reconcile()
+        override fun onDisplayChanged(displayId: Int) = reconcile()
+    }
+
+    fun start() {
+        displayManager.registerDisplayListener(listener, handler)
+        reconcile()
+    }
+
+    fun reconcile() {
+        val target = if (enabled)
+            displayManager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION).firstOrNull()
+        else
+            null
+
+        if (target == null || target.displayId != presentation?.display?.displayId) {
+            // dismiss(), when a presentation actually exists, invokes the onDismissListener
+            // below synchronously (we're always called from the main thread) - that already
+            // clears `presentation` and notifies, so there's nothing more to do here.
+            presentation?.dismiss()
+        }
+
+        if (target != null && presentation == null) {
+            Log.v(TAG, "Showing presentation on display ${target.displayId} (${target.name})")
+            presentation = ExternalDisplayPresentation(context, target).also {
+                it.setOnDismissListener {
+                    presentation = null
+                    MPVSurfaceCoordinator.externalDisplayActive = false
+                    onStateChanged(false)
+                }
+                it.show()
+            }
+            MPVSurfaceCoordinator.externalDisplayActive = true
+            onStateChanged(true)
+        }
+    }
+
+    fun release() {
+        displayManager.unregisterDisplayListener(listener)
+        presentation?.dismiss()
+        presentation = null
+        MPVSurfaceCoordinator.externalDisplayActive = false
+    }
+
+    companion object {
+        private const val TAG = "mpv"
+    }
+}

--- a/app/src/main/java/is/xyz/mpv/ExternalDisplayPresentation.kt
+++ b/app/src/main/java/is/xyz/mpv/ExternalDisplayPresentation.kt
@@ -1,0 +1,28 @@
+package `is`.xyz.mpv
+
+import android.app.Presentation
+import android.content.Context
+import android.os.Bundle
+import android.view.Display
+import android.view.SurfaceView
+import android.view.ViewGroup
+
+/**
+ * Minimal window shown on an external (secondary) display: just a full-bleed [SurfaceView] that
+ * registers itself with [MPVSurfaceCoordinator], the same way the phone's [MPVView] does.
+ */
+class ExternalDisplayPresentation(
+    context: Context,
+    display: Display,
+) : Presentation(context, display) {
+    private val surfaceCallback = MPVSurfaceCallback.forPresentation()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val surfaceView = SurfaceView(context)
+        setContentView(surfaceView, ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        surfaceView.holder.addCallback(surfaceCallback)
+    }
+}

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -1763,9 +1763,7 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         binding.playBtn.setImageResource(r)
 
         updatePiPParams()
-        // While projecting to an external display, let the phone screen time out on its own
-        // instead of forcing it to stay on.
-        if (paused || externalDisplayManager?.isActive == true) {
+        if (paused) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/app/src/main/java/is/xyz/mpv/MPVActivity.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVActivity.kt
@@ -85,6 +85,8 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
 
     private lateinit var binding: PlayerBinding
     private lateinit var gestures: TouchGestures
+    // null until onCreate's file-path check passes (player.initialize() must run first)
+    private var externalDisplayManager: ExternalDisplayManager? = null
 
     // convenience alias
     private val player get() = binding.player
@@ -186,6 +188,8 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
     private var newIntentReplace = false
 
     private var smoothSeekGesture = false
+
+    private var externalDisplayEnabledPref = true
     /* * */
 
     @SuppressLint("ClickableViewAccessibility")
@@ -306,6 +310,13 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         player.initialize(filesDir.path, cacheDir.path)
         player.playFile(filepath)
 
+        externalDisplayManager = ExternalDisplayManager(this) { active ->
+            onExternalDisplayStateChanged(active)
+        }.also {
+            it.enabled = externalDisplayEnabledPref
+            it.start()
+        }
+
         mediaSession = initMediaSession()
         updateMediaSession()
         with (BackgroundPlaybackService) {
@@ -347,6 +358,8 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
 
         // Suppress any further callbacks
         activityIsForeground = false
+
+        externalDisplayManager?.release()
 
         if (becomingNoisyReceiverRegistered) {
             unregisterReceiver(becomingNoisyReceiver)
@@ -418,9 +431,31 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         return image.isNullOrEmpty() || image == "yes"
     }
 
+    private fun onExternalDisplayStateChanged(active: Boolean) {
+        // covers the phone's own video surface so it goes black instead of showing a frozen
+        // last frame once mpv stops rendering to it
+        binding.externalDisplayBlankOverlay.isVisible = active
+
+        BackgroundPlaybackService.setExternalDisplayActive(active)
+        if (active) {
+            showToast(getString(R.string.notice_external_display_connected))
+        } else if (!activityIsForeground && !isFinishing && !shouldBackground()) {
+            // the display just disappeared while we were backgrounded purely to keep projecting,
+            // and nothing else (background_play) justifies staying unpaused
+            player.paused = true
+            BackgroundPlaybackService.thumbnail = null
+            updateMediaSession()
+        }
+        updatePlaybackStatus(psc.pause)
+    }
+
     private fun shouldBackground(): Boolean {
         if (isFinishing) // about to exit?
             return false
+        // playback is visibly happening on an external display, so it must continue regardless
+        // of what the user configured for phone-only backgrounding
+        if (externalDisplayManager?.isActive == true)
+            return true
         return when (backgroundPlayMode) {
             "always" -> true
             "audio-only" -> isPlayingAudioOnly()
@@ -478,6 +513,9 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
             Log.v(TAG, "Resuming playback in background")
             stopServiceHandler.removeCallbacks(stopServiceRunnable)
             val serviceIntent = Intent(this, BackgroundPlaybackService::class.java)
+            serviceIntent.putExtra(
+                BackgroundPlaybackService.EXTRA_EXTERNAL_DISPLAY_ACTIVE,
+                externalDisplayManager?.isActive == true)
             if (!tryStartForegroundService(serviceIntent)) {
                 didResumeBackgroundPlayback = false
                 player.paused = true
@@ -517,6 +555,8 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         this.playlistExitWarning = prefs.getBoolean("playlist_exit_warning", true)
         this.newIntentReplace = prefs.getBoolean("new_intent_replace", false)
         this.smoothSeekGesture = prefs.getBoolean("seek_gesture_smooth", false)
+        this.externalDisplayEnabledPref = prefs.getBoolean("external_display_enabled", true)
+        externalDisplayManager?.enabled = externalDisplayEnabledPref
     }
 
     private fun writeSettings() {
@@ -1723,7 +1763,9 @@ class MPVActivity : AppCompatActivity(), MPVLib.EventObserver, TouchGesturesObse
         binding.playBtn.setImageResource(r)
 
         updatePiPParams()
-        if (paused) {
+        // While projecting to an external display, let the phone screen time out on its own
+        // instead of forcing it to stay on.
+        if (paused || externalDisplayManager?.isActive == true) {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/app/src/main/java/is/xyz/mpv/MPVSurfaceCallback.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVSurfaceCallback.kt
@@ -1,0 +1,35 @@
+package `is`.xyz.mpv
+
+import android.view.SurfaceHolder
+
+/**
+ * Generic [SurfaceHolder.Callback] that forwards events to [MPVSurfaceCoordinator], which decides
+ * whether this particular surface actually gets to be libmpv's render target. Used both by the
+ * phone's [MPVView] and by [ExternalDisplayPresentation]'s SurfaceView.
+ */
+class MPVSurfaceCallback(
+    private val onCreated: (SurfaceHolder) -> Unit,
+    private val onChanged: (SurfaceHolder, Int, Int) -> Unit,
+    private val onDestroyed: (SurfaceHolder) -> Unit,
+) : SurfaceHolder.Callback {
+    override fun surfaceCreated(holder: SurfaceHolder) = onCreated(holder)
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) =
+        onChanged(holder, width, height)
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) = onDestroyed(holder)
+
+    companion object {
+        fun forPhone() = MPVSurfaceCallback(
+            onCreated = MPVSurfaceCoordinator::phoneSurfaceCreated,
+            onChanged = MPVSurfaceCoordinator::phoneSurfaceChanged,
+            onDestroyed = MPVSurfaceCoordinator::phoneSurfaceDestroyed,
+        )
+
+        fun forPresentation() = MPVSurfaceCallback(
+            onCreated = MPVSurfaceCoordinator::presentationSurfaceCreated,
+            onChanged = MPVSurfaceCoordinator::presentationSurfaceChanged,
+            onDestroyed = MPVSurfaceCoordinator::presentationSurfaceDestroyed,
+        )
+    }
+}

--- a/app/src/main/java/is/xyz/mpv/MPVSurfaceCoordinator.kt
+++ b/app/src/main/java/is/xyz/mpv/MPVSurfaceCoordinator.kt
@@ -1,0 +1,142 @@
+package `is`.xyz.mpv
+
+import android.util.Log
+import android.view.SurfaceHolder
+
+/**
+ * Arbitrates which [SurfaceHolder] libmpv's video output is bound to.
+ *
+ * libmpv exposes exactly one render target ("wid") at a time (see render.cpp: a single static
+ * `surface` global). mpv-android can have two live surfaces simultaneously though: the phone's
+ * [MPVView] and, once an external display is connected, an [ExternalDisplayPresentation]'s
+ * [android.view.SurfaceView]. This object is the *only* thing allowed to call
+ * [MPVLib.attachSurface]/[MPVLib.detachSurface] or touch the `vo`/`force-window` properties, so
+ * exactly one surface owns `wid` at any time and a switch always goes through a clean
+ * detach-then-attach, matching the sequence already proven correct for the single-surface case.
+ */
+object MPVSurfaceCoordinator {
+    private const val TAG = "mpv"
+
+    private var voInUse: String = "gpu"
+    private var pendingFilePath: String? = null
+
+    private var phoneSurface: SurfaceHolder? = null
+    private var presentationSurface: SurfaceHolder? = null
+
+    /** Set by [ExternalDisplayManager] when a Presentation is being shown/dismissed. */
+    var externalDisplayActive: Boolean = false
+        set(value) {
+            field = value
+            reconcile()
+        }
+
+    private var currentTarget: SurfaceHolder? = null
+
+    /**
+     * Clears all state. Since this is a process-wide singleton, but libmpv's core and the phone's
+     * MPVView are recreated per-MPVActivity-instance (e.g. finish one video, then open another
+     * via "Open with" - same process, fresh Activity), stale [SurfaceHolder] references from a
+     * previous instance could otherwise linger. Call this once at the very start of
+     * [BaseMPVView.initialize], before [MPVLib.create] - i.e. before any MPVLib call would be
+     * valid, which is why this only touches plain fields and never reaches reconcile()'s MPVLib
+     * calls (both surfaces are already null by the time externalDisplayActive is reset).
+     */
+    fun reset() {
+        phoneSurface = null
+        presentationSurface = null
+        currentTarget = null
+        pendingFilePath = null
+        voInUse = "gpu"
+        externalDisplayActive = false
+    }
+
+    /**
+     * Sets the VO to use. It is automatically disabled/enabled as the active surface changes.
+     */
+    fun setVo(vo: String) {
+        voInUse = vo
+        MPVLib.setOptionString("vo", vo)
+    }
+
+    /**
+     * Set the first file to be played once a surface is ready.
+     */
+    fun setPendingFilePath(filePath: String) {
+        pendingFilePath = filePath
+    }
+
+    fun phoneSurfaceCreated(holder: SurfaceHolder) {
+        phoneSurface = holder
+        reconcile()
+    }
+
+    fun phoneSurfaceChanged(holder: SurfaceHolder, width: Int, height: Int) {
+        reportSizeIfCurrent(holder, width, height)
+    }
+
+    fun phoneSurfaceDestroyed(holder: SurfaceHolder) {
+        if (phoneSurface == holder)
+            phoneSurface = null
+        reconcile()
+    }
+
+    fun presentationSurfaceCreated(holder: SurfaceHolder) {
+        presentationSurface = holder
+        reconcile()
+    }
+
+    fun presentationSurfaceChanged(holder: SurfaceHolder, width: Int, height: Int) {
+        reportSizeIfCurrent(holder, width, height)
+    }
+
+    fun presentationSurfaceDestroyed(holder: SurfaceHolder) {
+        if (presentationSurface == holder)
+            presentationSurface = null
+        reconcile()
+    }
+
+    private fun reportSizeIfCurrent(holder: SurfaceHolder, width: Int, height: Int) {
+        if (currentTarget == holder)
+            MPVLib.setPropertyString("android-surface-size", "${width}x$height")
+    }
+
+    private fun reconcile() {
+        val desiredTarget = if (externalDisplayActive && presentationSurface != null)
+            presentationSurface
+        else
+            phoneSurface
+
+        if (desiredTarget == currentTarget)
+            return
+
+        if (currentTarget != null) {
+            Log.w(TAG, "detaching surface")
+            // Note that before calling detachSurface() we need to be sure that libmpv
+            // is done using the surface.
+            // FIXME: There could be a race condition here, because I don't think
+            // setting a property will wait for VO deinit.
+            MPVLib.setPropertyString("vo", "null")
+            MPVLib.setOptionString("force-window", "no")
+            MPVLib.detachSurface()
+        }
+
+        currentTarget = desiredTarget
+
+        if (desiredTarget != null) {
+            Log.w(TAG, "attaching surface")
+            MPVLib.attachSurface(desiredTarget.surface)
+            // This forces mpv to render subs/osd/whatever into our surface even if it would
+            // ordinarily not
+            MPVLib.setOptionString("force-window", "yes")
+
+            val filePath = pendingFilePath
+            if (filePath != null) {
+                MPVLib.command(arrayOf("loadfile", filePath))
+                pendingFilePath = null
+            } else {
+                // We disable video output when the previous target disappears, enable it back
+                MPVLib.setPropertyString("vo", voInUse)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/player.xml
+++ b/app/src/main/res/layout/player.xml
@@ -10,6 +10,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <!-- Covers the phone's video surface while it's not the render target (i.e. while
+         projecting to an external display), so it shows black instead of a frozen last frame. -->
+    <View
+        android:id="@+id/externalDisplayBlankOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/black"
+        android:visibility="gone" />
+
     <!-- so that insets can be applied as margins -->
     <RelativeLayout
         android:id="@+id/outside"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="unsaved_changes">Unsaved changes</string>
     <string name="notice_file_appended">File(s) appended to playlist</string>
     <string name="notice_file_play">Starting playback of file(s)</string>
+    <string name="notice_external_display_connected">Playing on external display</string>
     <string name="exit_warning_playlist">%d playlist items remaining.\nDo you really want to exit?</string>
     <string name="contrast">Contrast</string>
     <string name="video_brightness">Video brightness</string>
@@ -120,6 +121,9 @@
 
     <string name="pref_save_position_title">Save position on quit</string>
     <string name="pref_save_position_summary">Remember current playback position on exit. When the same file is played again mpv will seek to the previous position.</string>
+
+    <string name="pref_external_display_title">External display projection</string>
+    <string name="pref_external_display_summary">When an HDMI/USB-C/wireless display is connected, play video on it instead and let the phone screen turn off.</string>
 
     <string name="pref_remember_brightness_title">Remember screen brightness</string>
     <string name="pref_remember_brightness_summary">Restore previously set screen brightness at player startup.</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -62,4 +62,11 @@
         android:summary="@string/pref_new_intent_replace_summary"
         android:title="@string/pref_new_intent_replace_title" />
 
+    <SwitchPreferenceCompat
+        android:defaultValue="true"
+        app:iconSpaceReserved="false"
+        android:key="external_display_enabled"
+        android:summary="@string/pref_external_display_summary"
+        android:title="@string/pref_external_display_title" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Lets video play on an external display via `android.app.Presentation`, so the phone screen can turn off without stopping playback. The phone shows the usual control ui, times out to just a black screen, and comes back when tapped.

Controlled by a new setting `General -> External display projection` on by default.

### Implementation

`ExternalDisplayManager` watches for a presentation-capable display and shows/dismisses a bare `SurfaceView` Presentation on it. Since libmpv only has one video output target, a new `MPVSurfaceCoordinator` arbitrates between the phone's surface and the Presentation's, doing a clean detach/attach on handoff. Projecting is treated like `background_play=always` (won't pause on backgrounding, starts the background service + a wake lock).

Code written by sonnet 5 high and tested manually. I read it over but don't have experience with android or this codebase.

### Testing

Tested on a OnePlus 15 with xreal xbx a01+ glasses in mirroring mode:
* plug in / unplug mid-playback
* cold start with glasses already connected
* settings toggle
* backgrounding via home button

Note that locking the phone blanks both displays.